### PR TITLE
fix(webhooks): use 'subscriptions' instead of 'events' field

### DIFF
--- a/src/components/webhooks/create-webhook-dialog.tsx
+++ b/src/components/webhooks/create-webhook-dialog.tsx
@@ -29,7 +29,7 @@ export function CreateWebhookDialog({
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
     url: '',
-    events: [] as string[],
+    subscriptions: [] as string[],
     enabled: true
   })
 
@@ -46,7 +46,7 @@ export function CreateWebhookDialog({
       return
     }
 
-    if (formData.events.length === 0) {
+    if (formData.subscriptions.length === 0) {
       toast.error('At least one event must be selected')
       return
     }
@@ -64,14 +64,14 @@ export function CreateWebhookDialog({
     try {
       await api.webhooks.create({
         url: formData.url.trim(),
-        events: formData.events,
+        subscriptions: formData.subscriptions,
         enabled: formData.enabled
       })
-      
+
       // Reset form
       setFormData({
         url: '',
-        events: [],
+        subscriptions: [],
         enabled: true
       })
       
@@ -86,27 +86,27 @@ export function CreateWebhookDialog({
   const handleEventToggle = (event: string, checked: boolean) => {
     setFormData(prev => ({
       ...prev,
-      events: checked 
-        ? [...prev.events, event]
-        : prev.events.filter(e => e !== event)
+      subscriptions: checked
+        ? [...prev.subscriptions, event]
+        : prev.subscriptions.filter(e => e !== event)
     }))
   }
 
   const handleSelectAllInGroup = (groupEvents: string[], checked: boolean) => {
     setFormData(prev => ({
       ...prev,
-      events: checked
-        ? [...new Set([...prev.events, ...groupEvents])]
-        : prev.events.filter(e => !groupEvents.includes(e))
+      subscriptions: checked
+        ? [...new Set([...prev.subscriptions, ...groupEvents])]
+        : prev.subscriptions.filter(e => !groupEvents.includes(e))
     }))
   }
 
   const isGroupFullySelected = (groupEvents: string[]) => {
-    return groupEvents.every(event => formData.events.includes(event))
+    return groupEvents.every(event => formData.subscriptions.includes(event))
   }
 
   const isGroupPartiallySelected = (groupEvents: string[]) => {
-    return groupEvents.some(event => formData.events.includes(event)) && 
+    return groupEvents.some(event => formData.subscriptions.includes(event)) &&
            !isGroupFullySelected(groupEvents)
   }
 
@@ -161,7 +161,7 @@ export function CreateWebhookDialog({
               <CardHeader>
                 <CardTitle>Event Subscriptions</CardTitle>
                 <CardDescription>
-                  Select which events should trigger this webhook ({formData.events.length} selected)
+                  Select which events should trigger this webhook ({formData.subscriptions.length} selected)
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -195,7 +195,7 @@ export function CreateWebhookDialog({
                             <div key={event} className="flex items-center space-x-2">
                               <Checkbox
                                 id={event}
-                                checked={formData.events.includes(event)}
+                                checked={formData.subscriptions.includes(event)}
                                 onCheckedChange={(checked) => handleEventToggle(event, checked as boolean)}
                               />
                               <Label htmlFor={event} className="text-sm font-mono">
@@ -224,7 +224,7 @@ export function CreateWebhookDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading || formData.events.length === 0}>
+            <Button type="submit" disabled={loading || formData.subscriptions.length === 0}>
               {loading ? 'Creating...' : 'Create Webhook'}
             </Button>
           </DialogFooter>

--- a/src/components/webhooks/delete-webhook-dialog.tsx
+++ b/src/components/webhooks/delete-webhook-dialog.tsx
@@ -73,16 +73,16 @@ export function DeleteWebhookDialog({
             </div>
 
             <div>
-              <span className="text-sm font-medium">Events ({webhook.attributes.events.length}):</span>
+              <span className="text-sm font-medium">Events ({webhook.attributes.subscriptions.length}):</span>
               <div className="flex flex-wrap gap-1 mt-1">
-                {webhook.attributes.events.slice(0, 5).map((event) => (
+                {webhook.attributes.subscriptions.slice(0, 5).map((event) => (
                   <Badge key={event} variant="outline" className="text-xs">
                     {event}
                   </Badge>
                 ))}
-                {webhook.attributes.events.length > 5 && (
+                {webhook.attributes.subscriptions.length > 5 && (
                   <Badge variant="secondary" className="text-xs">
-                    +{webhook.attributes.events.length - 5} more
+                    +{webhook.attributes.subscriptions.length - 5} more
                   </Badge>
                 )}
               </div>

--- a/src/components/webhooks/edit-webhook-dialog.tsx
+++ b/src/components/webhooks/edit-webhook-dialog.tsx
@@ -32,7 +32,7 @@ export function EditWebhookDialog({
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
     url: '',
-    events: [] as string[],
+    subscriptions: [] as string[],
     enabled: true
   })
 
@@ -46,7 +46,7 @@ export function EditWebhookDialog({
     if (webhook) {
       setFormData({
         url: webhook.attributes.url,
-        events: [...webhook.attributes.events],
+        subscriptions: [...webhook.attributes.subscriptions],
         enabled: webhook.attributes.enabled
       })
     }
@@ -60,7 +60,7 @@ export function EditWebhookDialog({
       return
     }
 
-    if (formData.events.length === 0) {
+    if (formData.subscriptions.length === 0) {
       toast.error('At least one event must be selected')
       return
     }
@@ -78,7 +78,7 @@ export function EditWebhookDialog({
     try {
       await api.webhooks.update(webhook.id, {
         url: formData.url.trim(),
-        events: formData.events,
+        subscriptions: formData.subscriptions,
         enabled: formData.enabled
       })
       
@@ -96,8 +96,8 @@ export function EditWebhookDialog({
     setFormData(prev => ({
       ...prev,
       events: checked 
-        ? [...prev.events, event]
-        : prev.events.filter(e => e !== event)
+        ? [...prev.subscriptions, event]
+        : prev.subscriptions.filter(e => e !== event)
     }))
   }
 
@@ -105,17 +105,17 @@ export function EditWebhookDialog({
     setFormData(prev => ({
       ...prev,
       events: checked
-        ? [...new Set([...prev.events, ...groupEvents])]
-        : prev.events.filter(e => !groupEvents.includes(e))
+        ? [...new Set([...prev.subscriptions, ...groupEvents])]
+        : prev.subscriptions.filter(e => !groupEvents.includes(e))
     }))
   }
 
   const isGroupFullySelected = (groupEvents: string[]) => {
-    return groupEvents.every(event => formData.events.includes(event))
+    return groupEvents.every(event => formData.subscriptions.includes(event))
   }
 
   const isGroupPartiallySelected = (groupEvents: string[]) => {
-    return groupEvents.some(event => formData.events.includes(event)) && 
+    return groupEvents.some(event => formData.subscriptions.includes(event)) && 
            !isGroupFullySelected(groupEvents)
   }
 
@@ -170,7 +170,7 @@ export function EditWebhookDialog({
               <CardHeader>
                 <CardTitle>Event Subscriptions</CardTitle>
                 <CardDescription>
-                  Select which events should trigger this webhook ({formData.events.length} selected)
+                  Select which events should trigger this webhook ({formData.subscriptions.length} selected)
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -204,7 +204,7 @@ export function EditWebhookDialog({
                             <div key={event} className="flex items-center space-x-2">
                               <Checkbox
                                 id={event}
-                                checked={formData.events.includes(event)}
+                                checked={formData.subscriptions.includes(event)}
                                 onCheckedChange={(checked) => handleEventToggle(event, checked as boolean)}
                               />
                               <Label htmlFor={event} className="text-sm font-mono">
@@ -233,7 +233,7 @@ export function EditWebhookDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading || formData.events.length === 0}>
+            <Button type="submit" disabled={loading || formData.subscriptions.length === 0}>
               {loading ? 'Updating...' : 'Update Webhook'}
             </Button>
           </DialogFooter>

--- a/src/components/webhooks/webhook-details-dialog.tsx
+++ b/src/components/webhooks/webhook-details-dialog.tsx
@@ -93,7 +93,7 @@ export function WebhookDetailsDialog({
     return groups
   }
 
-  const eventGroups = groupEventsByResource(webhook.attributes.events)
+  const eventGroups = groupEventsByResource(webhook.attributes.subscriptions)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -193,7 +193,7 @@ export function WebhookDetailsDialog({
           {/* Event Subscriptions */}
           <Card>
             <CardHeader>
-              <CardTitle>Event Subscriptions ({webhook.attributes.events.length})</CardTitle>
+              <CardTitle>Event Subscriptions ({webhook.attributes.subscriptions.length})</CardTitle>
               <CardDescription>
                 Events that will trigger this webhook
               </CardDescription>

--- a/src/components/webhooks/webhook-management.tsx
+++ b/src/components/webhooks/webhook-management.tsx
@@ -120,7 +120,7 @@ export function WebhookManagement() {
 
   const filteredWebhooks = webhooks.filter(webhook => 
     webhook.attributes.url.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    webhook.attributes.events.some(event => event.toLowerCase().includes(searchTerm.toLowerCase()))
+    webhook.attributes.subscriptions.some(event => event.toLowerCase().includes(searchTerm.toLowerCase()))
   )
 
   const formatDate = (dateString: string) => {
@@ -213,14 +213,14 @@ export function WebhookManagement() {
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-1">
-                          {webhook.attributes.events.slice(0, 3).map((event) => (
+                          {webhook.attributes.subscriptions.slice(0, 3).map((event) => (
                             <Badge key={event} variant="outline" className="text-xs">
                               {event}
                             </Badge>
                           ))}
-                          {webhook.attributes.events.length > 3 && (
+                          {webhook.attributes.subscriptions.length > 3 && (
                             <Badge variant="secondary" className="text-xs">
-                              +{webhook.attributes.events.length - 3} more
+                              +{webhook.attributes.subscriptions.length - 3} more
                             </Badge>
                           )}
                         </div>

--- a/src/lib/api/resources/webhooks.ts
+++ b/src/lib/api/resources/webhooks.ts
@@ -57,8 +57,8 @@ export class WebhookResource {
     // Add filter parameters
     if (filters.enabled !== undefined) params.enabled = filters.enabled;
     if (filters.url) params.url = filters.url;
-    if (filters.events && filters.events.length > 0) {
-      params.events = filters.events.join(',');
+    if (filters.subscriptions && filters.subscriptions.length > 0) {
+      params.subscriptions = filters.subscriptions.join(',');
     }
 
     return this.client.request<Webhook[]>('webhook-endpoints', { params });
@@ -76,7 +76,7 @@ export class WebhookResource {
    */
   async create(webhookData: {
     url: string;
-    events: string[];
+    subscriptions: string[];
     enabled?: boolean;
   }): Promise<KeygenResponse<Webhook>> {
     const body = {
@@ -84,7 +84,7 @@ export class WebhookResource {
         type: 'webhook-endpoints',
         attributes: {
           url: webhookData.url.trim(),
-          events: webhookData.events,
+          subscriptions: webhookData.subscriptions,
           enabled: webhookData.enabled !== false, // Default to true
         },
       },
@@ -101,7 +101,7 @@ export class WebhookResource {
    */
   async update(id: string, updates: {
     url?: string;
-    events?: string[];
+    subscriptions?: string[];
     enabled?: boolean;
   }): Promise<KeygenResponse<Webhook>> {
     const body = {
@@ -110,7 +110,7 @@ export class WebhookResource {
         id,
         attributes: {
           ...(updates.url && { url: updates.url.trim() }),
-          ...(updates.events && { events: updates.events }),
+          ...(updates.subscriptions && { subscriptions: updates.subscriptions }),
           ...(updates.enabled !== undefined && { enabled: updates.enabled }),
         },
       },

--- a/src/lib/types/keygen.ts
+++ b/src/lib/types/keygen.ts
@@ -253,7 +253,7 @@ export interface Webhook extends KeygenResource {
   type: 'webhook-endpoints';
   attributes: {
     url: string;
-    events: string[];
+    subscriptions: string[];
     signingKey?: string;
     enabled: boolean;
     created: string;
@@ -338,5 +338,5 @@ export interface RequestLogFilters extends PaginationOptions {
 export interface WebhookFilters extends PaginationOptions {
   enabled?: boolean;
   url?: string;
-  events?: string[];
+  subscriptions?: string[];
 }


### PR DESCRIPTION
## Summary
- Changed webhook attribute from `events` to `subscriptions` to match Keygen API specification
- Updated Webhook interface and WebhookFilters type
- Updated webhook API resource methods (create, update, list)
- Updated all webhook UI components

## Files Changed
- `src/lib/types/keygen.ts` - Webhook interface and WebhookFilters
- `src/lib/api/resources/webhooks.ts` - API methods
- `src/components/webhooks/create-webhook-dialog.tsx`
- `src/components/webhooks/edit-webhook-dialog.tsx`
- `src/components/webhooks/delete-webhook-dialog.tsx`
- `src/components/webhooks/webhook-details-dialog.tsx`
- `src/components/webhooks/webhook-management.tsx`

## Test plan
- [ ] Create a new webhook with event subscriptions
- [ ] Verify webhook is created successfully
- [ ] Edit webhook subscriptions
- [ ] Verify existing webhooks display correctly

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)