### PR TITLE
fix(users): only send defined attributes in user creation request

### DIFF
--- a/src/lib/api/resources/users.ts
+++ b/src/lib/api/resources/users.ts
@@ -38,17 +38,24 @@ export class UserResource {
     password?: string;
     metadata?: Record<string, unknown>;
   }): Promise<KeygenResponse<User>> {
+    // Build attributes object, only including defined values
+    const attributes: Record<string, unknown> = {
+      email: userData.email,
+    };
+
+    // Only add optional fields if they have values
+    if (userData.firstName) attributes.firstName = userData.firstName;
+    if (userData.lastName) attributes.lastName = userData.lastName;
+    if (userData.role) attributes.role = userData.role;
+    if (userData.password) attributes.password = userData.password;
+    if (userData.metadata && Object.keys(userData.metadata).length > 0) {
+      attributes.metadata = userData.metadata;
+    }
+
     const body = {
       data: {
         type: 'users',
-        attributes: {
-          firstName: userData.firstName,
-          lastName: userData.lastName,
-          email: userData.email,
-          role: userData.role || 'user',
-          password: userData.password,
-          metadata: userData.metadata || {},
-        },
+        attributes,
       },
     };
 


### PR DESCRIPTION
## Summary
- Fixed user creation API call that was sending undefined values and empty objects
- Now only sends attributes that have actual values defined

## Root Cause
The previous implementation was sending all attributes including:
- `undefined` values for optional fields like firstName, lastName
- Empty `{}` for metadata even when not provided
- Default role even when not needed

Some API implementations may reject requests with undefined/null values or treat them differently than omitted fields.

## Changes
Only includes attributes in the request body if they have values:
- `email` - always included (required)
- `firstName`, `lastName` - only if provided
- `role` - only if explicitly set
- `password` - only if provided
- `metadata` - only if provided and non-empty

## Test plan
- [ ] Create a user with only email and password
- [ ] Verify user appears in the users list
- [ ] Create a user with all fields populated
- [ ] Verify all attributes are saved correctly

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)