### PR TITLE
Improve error messages for policy creation and validation errors

### DIFF
--- a/src/lib/utils/error-handling.ts
+++ b/src/lib/utils/error-handling.ts
@@ -15,7 +15,8 @@ import {
   isUnauthorizedError,
   getErrorMessage,
   getErrorStatus,
-  shouldShowToast
+  shouldShowToast,
+  getCombinedErrorMessage
 } from './error-guards'
 
 /**
@@ -46,7 +47,9 @@ export function handleCrudError(
   }
 
   if (isUnprocessableEntityError(error)) {
-    const message = options?.customMessage || `Invalid ${resourceType.toLowerCase()} data - please check your input`
+    // Extract detailed error message from API response
+    const detailedMessage = getCombinedErrorMessage(error)
+    const message = options?.customMessage || detailedMessage || `Invalid ${resourceType.toLowerCase()} data - please check your input`
     if (options?.onValidation) {
       options.onValidation(message)
     }
@@ -158,7 +161,9 @@ export function handleFormError(
   }
 
   if (isUnprocessableEntityError(error)) {
-    const message = 'Please check your input and try again'
+    // Extract detailed error message from API response
+    const detailedMessage = getCombinedErrorMessage(error)
+    const message = detailedMessage || 'Please check your input and try again'
     if (options?.onValidation) {
       options.onValidation(message)
     } else if (shouldShowToast(error)) {


### PR DESCRIPTION
## Summary
- Add `getDetailedErrorMessages()` function to extract specific error details from Keygen API responses
- Add `getCombinedErrorMessage()` to combine multiple errors into a single user-friendly message
- Update `handleCrudError()` to show detailed API error messages for 422 (Unprocessable Entity) errors
- Update `handleFormError()` to show detailed API error messages for 422 errors

## Problem
When policy creation fails due to validation errors (e.g., "duration is too small"), the error message only shows a generic "please check your input" message instead of the actual error details from the API.

## Solution
The error handling now extracts the `detail` field from the API's error response and shows it to the user. For example:
- Before: "Please check your input and try again"
- After: "Duration: is too small" or "is too small" (depending on the error structure)

The solution also handles multiple errors by combining them with periods.

Fixes #5

## Test plan
- [ ] Create a policy with invalid data (e.g., very small duration value)
- [ ] Verify the error message shows the specific validation error from the API
- [ ] Test with multiple validation errors to ensure they're all displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)