### PR TITLE
fix(proxy): use node-fetch to resolve SSL certificate errors

### DIFF
--- a/docs/project-documentation.md
+++ b/docs/project-documentation.md
@@ -121,10 +121,15 @@ Key references:
 - Loading & error states: always present on async flows
 - Notifications: Sonner for success/error toasts
 
+## API Proxy
+
+Browser requests are routed through a Next.js API proxy at `/api/keygen/[...path]` to avoid CORS issues when the app is accessed from other machines on the network. The proxy uses `node-fetch` with a custom HTTPS agent to handle self-signed certificates in development (`rejectUnauthorized: false`). In production, certificate validation is enforced.
+
 ## Security
 
 - Never embed admin/product/environment tokens in client code
 - Use HTTPS and secure CORS in production
+- The API proxy validates SSL certificates in production but relaxes this for development self-signed certs
 - Validate inputs client-side and server-side (where applicable)
 - Handle auth failures and token expiry gracefully
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
+    "node-fetch": "^3.3.2",
     "react": "19.2.3",
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1753,6 +1756,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2023,6 +2030,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2045,6 +2056,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2499,6 +2514,15 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -2974,6 +2998,10 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4516,6 +4544,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4950,6 +4980,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4973,6 +5008,10 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   fsevents@2.3.3:
     optional: true
@@ -5391,6 +5430,14 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.27: {}
 
@@ -5995,6 +6042,8 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  web-streams-polyfill@3.3.3: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/api/keygen/[...path]/route.ts
+++ b/src/app/api/keygen/[...path]/route.ts
@@ -1,36 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
+import https from 'https'
+import nodeFetch from 'node-fetch'
 
 const KEYGEN_API_URL = process.env.NEXT_PUBLIC_KEYGEN_API_URL || 'https://api.keygen.sh/v1'
 
-async function proxyRequest(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params
-  const targetPath = path.join('/')
-  const targetUrl = new URL(`${KEYGEN_API_URL}/${targetPath}`)
+// Extract base URL without /v1 suffix
+const BASE_URL = KEYGEN_API_URL.replace(/\/v1\/?$/, '')
 
-  // Preserve query parameters
-  request.nextUrl.searchParams.forEach((value, key) => {
-    targetUrl.searchParams.append(key, value)
-  })
+// Create an HTTPS agent that ignores self-signed certificate errors in development
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: process.env.NODE_ENV === 'production',
+})
 
-  // Build headers to forward
-  const headers: Record<string, string> = {}
+async function proxyRequest(request: NextRequest, path: string[]) {
+  const targetUrl = `${BASE_URL}/v1/${path.join('/')}${request.nextUrl.search}`
 
+  const headers: Record<string, string> = {
+    'Content-Type': request.headers.get('content-type') || 'application/vnd.api+json',
+    'Accept': request.headers.get('accept') || 'application/vnd.api+json',
+  }
+
+  // Forward auth header
   const authorization = request.headers.get('authorization')
   if (authorization) {
     headers['Authorization'] = authorization
-  }
-
-  const contentType = request.headers.get('content-type')
-  if (contentType) {
-    headers['Content-Type'] = contentType
-  }
-
-  const accept = request.headers.get('accept')
-  if (accept) {
-    headers['Accept'] = accept
   }
 
   // Read request body for non-GET/HEAD methods
@@ -43,63 +36,67 @@ async function proxyRequest(
     }
   }
 
-  const response = await fetch(targetUrl.toString(), {
-    method: request.method,
-    headers,
-    body: body || undefined,
-  })
+  try {
+    const response = await nodeFetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: body || undefined,
+      agent: targetUrl.startsWith('https') ? httpsAgent : undefined,
+    })
 
-  // Handle empty responses (e.g., DELETE 204)
-  if (response.status === 204 || response.headers.get('content-length') === '0') {
-    return new NextResponse(null, {
+    const data = await response.text()
+
+    return new NextResponse(data || null, {
       status: response.status,
       headers: {
-        'Content-Type': 'application/vnd.api+json',
+        'Content-Type': response.headers.get('content-type') || 'application/vnd.api+json',
       },
     })
+  } catch (error) {
+    console.error('Proxy error:', error)
+    return NextResponse.json(
+      { errors: [{ title: 'Proxy Error', detail: String(error) }] },
+      { status: 502 }
+    )
   }
-
-  const responseBody = await response.text()
-
-  return new NextResponse(responseBody, {
-    status: response.status,
-    headers: {
-      'Content-Type': response.headers.get('content-type') || 'application/vnd.api+json',
-    },
-  })
 }
 
 export async function GET(
   request: NextRequest,
-  context: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  return proxyRequest(request, context)
+  const { path } = await params
+  return proxyRequest(request, path)
 }
 
 export async function POST(
   request: NextRequest,
-  context: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  return proxyRequest(request, context)
+  const { path } = await params
+  return proxyRequest(request, path)
 }
 
 export async function PUT(
   request: NextRequest,
-  context: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  return proxyRequest(request, context)
+  const { path } = await params
+  return proxyRequest(request, path)
 }
 
 export async function PATCH(
   request: NextRequest,
-  context: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  return proxyRequest(request, context)
+  const { path } = await params
+  return proxyRequest(request, path)
 }
 
 export async function DELETE(
   request: NextRequest,
-  context: { params: Promise<{ path: string[] }> }
+  { params }: { params: Promise<{ path: string[] }> }
 ) {
-  return proxyRequest(request, context)
+  const { path } = await params
+  return proxyRequest(request, path)
 }


### PR DESCRIPTION
## Summary
- Replaces native `fetch` with `node-fetch` in the API proxy route to fix `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` errors when proxying to HTTPS backends with self-signed certificates
- Adds a custom HTTPS agent that relaxes certificate validation in development (`rejectUnauthorized: false`) while enforcing it in production
- Adds proper error handling with 502 responses on proxy failures

Fixes #16

## Context
Reported by @jstumpin in [#16 comment](https://github.com/orcunbaslak/keygen-ui/issues/16#issuecomment-3882731414). The previous CORS proxy fix (#17) used native `fetch` which doesn't support custom SSL agents, causing SSL certificate validation failures for self-hosted Keygen instances with self-signed certs.

## Changes
- `src/app/api/keygen/[...path]/route.ts` — switched from native `fetch` to `node-fetch` with HTTPS agent
- `package.json` — added `node-fetch@^3.3.2` dependency
- `docs/project-documentation.md` — documented API proxy behavior

## Test plan
- [ ] Verify `pnpm typecheck` passes
- [ ] Verify `pnpm build` succeeds
- [ ] Test proxy works with self-signed HTTPS backend
- [ ] Test proxy works with valid HTTPS backend
- [ ] Test proxy works with HTTP backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)