### PR TITLE
feat(api): support Keygen CE singleplayer mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ KEYGEN_ADMIN_PASSWORD=your-secure-password
 # Account ID will be retrieved after first login
 NEXT_PUBLIC_KEYGEN_ACCOUNT_ID=
 
+# Set to true for Keygen CE singleplayer mode (omits accounts/{id} from API paths)
+# NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true
+
 # Next.js configuration
 NEXTAUTH_SECRET=generate-with-openssl-rand-base64-32
 NEXTAUTH_URL=http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,9 @@ KEYGEN_API_URL=https://lms.pvx.ai/v1
 KEYGEN_ACCOUNT_ID=aca05a24-461a-4db5-8ed1-c12b6040d1c6
 KEYGEN_ADMIN_EMAIL=orcun@pvx.ai
 KEYGEN_ADMIN_PASSWORD=[configured]
+
+# Optional: for Keygen CE singleplayer mode (omits accounts/{id} from API paths)
+# NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true
 ```
 
 ## Implemented Features

--- a/docs/project-documentation.md
+++ b/docs/project-documentation.md
@@ -62,6 +62,9 @@ KEYGEN_API_URL=<https://api.keygen.sh/v1 or your instance>
 KEYGEN_ACCOUNT_ID=<account-id>
 KEYGEN_ADMIN_EMAIL=<email>
 KEYGEN_ADMIN_PASSWORD=<password>
+
+# Optional: for Keygen CE singleplayer mode (omits accounts/{id} from API paths)
+# NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true
 ```
 
 Commands:

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -20,6 +20,7 @@ export interface KeygenClientConfig {
   apiUrl: string;
   accountId: string;
   token?: string;
+  singleplayer?: boolean;
 }
 
 export class KeygenClient {
@@ -188,10 +189,14 @@ export class KeygenClient {
   /**
    * Build the full URL for an endpoint
    * In the browser, routes through /api/keygen proxy to avoid CORS issues
+   * In singleplayer CE mode, omits the accounts/{accountId} path segment
    */
   private buildUrl(endpoint: string): string {
     const isBrowser = typeof window !== 'undefined'
     const proxyBase = '/api/keygen'
+    const accountPrefix = this.config.singleplayer
+      ? ''
+      : `/accounts/${this.config.accountId}`
 
     if (endpoint.startsWith('/')) {
       // Absolute endpoint (e.g., '/tokens', '/me')
@@ -206,16 +211,20 @@ export class KeygenClient {
       }
       // e.g., '/tokens' → proxy: /api/keygen/accounts/{id}/tokens
       if (isBrowser) {
-        return `${proxyBase}/accounts/${this.config.accountId}${endpoint}`
+        return `${proxyBase}${accountPrefix}${endpoint}`
       }
-      return `${this.config.apiUrl}/accounts/${this.config.accountId}${endpoint}`
+      return `${this.config.apiUrl}${accountPrefix}${endpoint}`
     }
 
     // Relative endpoint (e.g., 'licenses')
     if (isBrowser) {
-      return `${proxyBase}/accounts/${this.config.accountId}/${endpoint}`
+      return accountPrefix
+        ? `${proxyBase}${accountPrefix}/${endpoint}`
+        : `${proxyBase}/${endpoint}`
     }
-    return `${this.config.apiUrl}/accounts/${this.config.accountId}/${endpoint}`
+    return accountPrefix
+      ? `${this.config.apiUrl}${accountPrefix}/${endpoint}`
+      : `${this.config.apiUrl}/${endpoint}`
   }
 
   /**
@@ -286,14 +295,20 @@ export function getKeygenClient(): KeygenClient {
   if (!clientInstance) {
     const apiUrl = process.env.NEXT_PUBLIC_KEYGEN_API_URL;
     const accountId = process.env.NEXT_PUBLIC_KEYGEN_ACCOUNT_ID;
+    const singleplayer = process.env.NEXT_PUBLIC_KEYGEN_SINGLEPLAYER === 'true';
 
-    if (!apiUrl || !accountId) {
-      throw new Error('Missing required environment variables: NEXT_PUBLIC_KEYGEN_API_URL and NEXT_PUBLIC_KEYGEN_ACCOUNT_ID');
+    if (!apiUrl) {
+      throw new Error('Missing required environment variable: NEXT_PUBLIC_KEYGEN_API_URL');
+    }
+
+    if (!singleplayer && !accountId) {
+      throw new Error('Missing required environment variable: NEXT_PUBLIC_KEYGEN_ACCOUNT_ID (set NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true for singleplayer CE mode)');
     }
 
     clientInstance = new KeygenClient({
       apiUrl,
-      accountId,
+      accountId: accountId || '',
+      singleplayer,
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true` env var to omit `accounts/{accountId}` from API URL paths
- Enables compatibility with Keygen CE singleplayer instances where account-scoped URLs are not used
- Updates `.env.example`, `CLAUDE.md`, and project docs with the new configuration option

Addresses feedback from @jstumpin in #16.

## Test plan
- [ ] Verify existing multiplayer mode works unchanged (no env var set)
- [ ] Set `NEXT_PUBLIC_KEYGEN_SINGLEPLAYER=true` and verify API calls omit the accounts path
- [ ] Confirm proxy route correctly forwards singleplayer paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)