### PR TITLE
fix(api): correct calls that target endpoints Keygen does not expose

### DIFF
--- a/src/components/entitlements/entitlement-details-dialog.tsx
+++ b/src/components/entitlements/entitlement-details-dialog.tsx
@@ -1,15 +1,11 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { getKeygenApi } from '@/lib/api'
-import { Entitlement, License } from '@/lib/types/keygen'
+import { Entitlement } from '@/lib/types/keygen'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Shield, KeyRound, Calendar, Info, Code } from 'lucide-react'
 // toast not needed; using centralized error handlers
-import { handleLoadError } from '@/lib/utils/error-handling'
 
 interface EntitlementDetailsDialogProps {
   entitlement: Entitlement
@@ -22,32 +18,6 @@ export function EntitlementDetailsDialog({
   open,
   onOpenChange
 }: EntitlementDetailsDialogProps) {
-  const [licenses, setLicenses] = useState<License[]>([])
-  const [loadingLicenses, setLoadingLicenses] = useState(false)
-  
-  const api = getKeygenApi()
-
-  const loadEntitlementDetails = useCallback(async () => {
-    if (!entitlement.id) return
-
-    // Load associated licenses
-    setLoadingLicenses(true)
-    try {
-      const licensesResponse = await api.entitlements.getLicenses(entitlement.id, { limit: 10 })
-      setLicenses((licensesResponse.data as License[]) || [])
-    } catch (error: unknown) {
-      handleLoadError(error, 'entitlement licenses')
-    } finally {
-      setLoadingLicenses(false)
-    }
-  }, [api.entitlements, entitlement.id])
-
-  useEffect(() => {
-    if (open && entitlement.id) {
-      loadEntitlementDetails()
-    }
-  }, [open, entitlement.id, loadEntitlementDetails])
-
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -121,71 +91,27 @@ export function EntitlementDetailsDialog({
             </CardContent>
           </Card>
 
-          {/* Associated Licenses */}
+          {/* Where this entitlement is used.
+
+              Keygen has no endpoint for "which licences carry this entitlement"
+              — /entitlements is a flat resource and /licenses has no entitlement
+              filter — so this explains the relationship rather than faking a list. */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <KeyRound className="h-4 w-4" />
-                Associated Licenses ({licenses.length})
+                Where it applies
               </CardTitle>
               <CardDescription>
-                Licenses that have this entitlement enabled (showing first 10)
+                Entitlements are attached to licences and policies, not the other way round
               </CardDescription>
             </CardHeader>
             <CardContent>
-              {loadingLicenses ? (
-                <div className="space-y-2">
-                  {[...Array(3)].map((_, i) => (
-                    <Skeleton key={i} className="h-8 w-full" />
-                  ))}
-                </div>
-              ) : licenses.length > 0 ? (
-                <div className="space-y-2">
-                  {licenses.map((license) => (
-                    <div key={license.id} className="flex items-center justify-between p-3 border rounded">
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">
-                          {license.attributes.name || 'Unnamed License'}
-                        </p>
-                        <p className="text-xs text-muted-foreground font-mono">
-                          {license.attributes.key}
-                        </p>
-                        <div className="flex items-center gap-2">
-                          <Badge variant={license.attributes.status === 'active' ? 'default' : 'secondary'}>
-                            {license.attributes.status}
-                          </Badge>
-                          {license.attributes.uses !== undefined && (
-                            <Badge variant="outline">
-                              Uses: {license.attributes.uses}
-                              {license.attributes.maxUses ? `/${license.attributes.maxUses}` : ''}
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-xs text-muted-foreground">
-                          Created: {new Date(license.attributes.created).toLocaleDateString()}
-                        </p>
-                        {license.attributes.expiry && (
-                          <p className="text-xs text-muted-foreground">
-                            Expires: {new Date(license.attributes.expiry).toLocaleDateString()}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <Shield className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-                  <p className="text-sm text-muted-foreground">
-                    No licenses are currently using this entitlement
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Licenses with this entitlement will appear here
-                  </p>
-                </div>
-              )}
+              <p className="text-muted-foreground text-sm">
+                Attach this entitlement to a <strong>policy</strong> to grant it to every
+                licence under that policy, or to an individual <strong>licence</strong> for
+                a one-off. Do that from the policy or licence itself.
+              </p>
             </CardContent>
           </Card>
 

--- a/src/lib/api/resources/entitlements.ts
+++ b/src/lib/api/resources/entitlements.ts
@@ -90,47 +90,13 @@ export class EntitlementResource {
   }
 
   /**
-   * Get entitlement licenses
+   * NOTE: entitlements are attached from the other side — Keygen mounts
+   * /entitlements as a flat resource with no sub-routes:
+   *
+   *   licenses.attachEntitlements(licenseId, [entitlementId])
+   *   policies.attachEntitlements(policyId, [entitlementId])
+   *
+   * There is likewise no way to list the licences carrying an entitlement:
+   * /licenses has no entitlement filter.
    */
-  async getLicenses(id: string, options: ListOptions = {}): Promise<KeygenResponse<unknown[]>> {
-    const params: Record<string, unknown> = {};
-    if (options.limit) params.limit = options.limit;
-    if (options.page) params.page = options.page;
-
-    return this.client.request(`entitlements/${id}/licenses`, { params });
-  }
-
-  /**
-   * Attach entitlement to licenses
-   */
-  async attachToLicenses(id: string, licenseIds: string[]): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: licenseIds.map(licenseId => ({
-        type: 'licenses',
-        id: licenseId,
-      })),
-    };
-
-    return this.client.request(`entitlements/${id}/relationships/licenses`, {
-      method: 'POST',
-      body,
-    });
-  }
-
-  /**
-   * Detach entitlement from licenses
-   */
-  async detachFromLicenses(id: string, licenseIds: string[]): Promise<void> {
-    const body = {
-      data: licenseIds.map(licenseId => ({
-        type: 'licenses',
-        id: licenseId,
-      })),
-    };
-
-    await this.client.request(`entitlements/${id}/relationships/licenses`, {
-      method: 'DELETE',
-      body,
-    });
-  }
 }

--- a/src/lib/api/resources/groups.ts
+++ b/src/lib/api/resources/groups.ts
@@ -127,27 +127,23 @@ export class GroupResource {
    * Add user to group
    */
   async addUser(id: string, userId: string): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: { type: 'users', id: userId },
-    };
-
-    return this.client.request(`groups/${id}/relationships/users`, {
-      method: 'POST',
-      body,
+    // Group membership is written on the member, not the group: Keygen exposes
+    // no attach endpoint under /groups/:id/users (only index/show).
+    return this.client.request(`users/${userId}/group`, {
+      method: 'PUT',
+      body: { data: { type: 'groups', id } },
     });
   }
 
   /**
    * Remove user from group
    */
-  async removeUser(id: string, userId: string): Promise<void> {
-    const body = {
-      data: { type: 'users', id: userId },
-    };
-
-    await this.client.request(`groups/${id}/relationships/users`, {
-      method: 'DELETE',
-      body,
+  async removeUser(id: string, userId: string): Promise<KeygenResponse<unknown>> {
+    void id;
+    // Clearing the member's group is how it leaves one.
+    return this.client.request(`users/${userId}/group`, {
+      method: 'PUT',
+      body: { data: null },
     });
   }
 
@@ -155,27 +151,20 @@ export class GroupResource {
    * Add license to group
    */
   async addLicense(id: string, licenseId: string): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: { type: 'licenses', id: licenseId },
-    };
-
-    return this.client.request(`groups/${id}/relationships/licenses`, {
-      method: 'POST',
-      body,
+    return this.client.request(`licenses/${licenseId}/group`, {
+      method: 'PUT',
+      body: { data: { type: 'groups', id } },
     });
   }
 
   /**
    * Remove license from group
    */
-  async removeLicense(id: string, licenseId: string): Promise<void> {
-    const body = {
-      data: { type: 'licenses', id: licenseId },
-    };
-
-    await this.client.request(`groups/${id}/relationships/licenses`, {
-      method: 'DELETE',
-      body,
+  async removeLicense(id: string, licenseId: string): Promise<KeygenResponse<unknown>> {
+    void id;
+    return this.client.request(`licenses/${licenseId}/group`, {
+      method: 'PUT',
+      body: { data: null },
     });
   }
 }

--- a/src/lib/api/resources/licenses.ts
+++ b/src/lib/api/resources/licenses.ts
@@ -101,7 +101,7 @@ export class LicenseResource {
       })),
     };
 
-    return this.client.request(`licenses/${id}/relationships/users`, {
+    return this.client.request(`licenses/${id}/users`, {
       method: 'POST',
       body,
     });
@@ -118,7 +118,7 @@ export class LicenseResource {
       })),
     };
 
-    await this.client.request(`licenses/${id}/relationships/users`, {
+    await this.client.request(`licenses/${id}/users`, {
       method: 'DELETE',
       body,
     });
@@ -243,7 +243,7 @@ export class LicenseResource {
       })),
     };
 
-    return this.client.request(`licenses/${id}/relationships/entitlements`, {
+    return this.client.request(`licenses/${id}/entitlements`, {
       method: 'POST',
       body,
     });
@@ -260,7 +260,7 @@ export class LicenseResource {
       })),
     };
 
-    await this.client.request(`licenses/${id}/relationships/entitlements`, {
+    await this.client.request(`licenses/${id}/entitlements`, {
       method: 'DELETE',
       body,
     });
@@ -295,7 +295,7 @@ export class LicenseResource {
       data: { type: 'users', id: userId },
     };
 
-    return this.client.request<License>(`licenses/${id}/user`, {
+    return this.client.request<License>(`licenses/${id}/owner`, {
       method: 'PUT',
       body,
     });

--- a/src/lib/api/resources/users.ts
+++ b/src/lib/api/resources/users.ts
@@ -189,7 +189,7 @@ export class UserResource {
       data: { type: 'groups', id: groupId },
     };
 
-    return this.client.request<User>(`users/${id}/relationships/group`, {
+    return this.client.request<User>(`users/${id}/group`, {
       method: 'PATCH',
       body,
     });


### PR DESCRIPTION
While integrating this dashboard against a self-hosted **Keygen CE 1.8** instance, I found several API calls that cannot succeed — they target routes that do not exist, and fail silently.

Every claim below is checkable against Keygen's own route table: [`config/routes.rb`](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb).

---

## 1. Relationship routes are mounted without a `/relationships/` segment

Keygen mounts them directly under the parent ([routes.rb#L223-L251](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L223-L251)):

```ruby
resources :licenses, constraints: { id: /[^\/]*/ } do
  scope module: 'licenses/relationships' do
    resources :entitlements, only: %i[index show] do
      collection do
        post '/',   to: 'entitlements#attach', as: :attach
        delete '/', to: 'entitlements#detach', as: :detach
      end
    end

    resources :users, only: %i[index show] do
      collection do
        post '/',   to: 'users#attach', as: :attach
        delete '/', to: 'users#detach', as: :detach
      end
    end

    resource :owner, only: %i[show update]
  end
end
```

So the paths are `/licenses/:id/entitlements` and `/licenses/:id/users` — **not** `/licenses/:id/relationships/...`. Same for `/users/:id/group` ([L208](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L208)).

**Impact:** `licenses.attachEntitlements()` and `licenses.attachUsers()` 404. Both are called by the create-license dialog, so **attaching entitlements or users while creating a license has never worked** — and because the failure is swallowed, the license is created without them and the user is told it succeeded.

Also switched `/licenses/:id/user` → `/licenses/:id/owner`: the former is the legacy v1.5 alias ([L247-L249](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L247-L249)).

## 2. There are no attach/detach routes under a group's users or licenses

Groups expose only `index`/`show` for their members ([L377-L389](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L377-L389)). Membership is written on the **member**, not the group:

```
PUT /users/:id/group
PUT /licenses/:id/group
```

`groups.addUser/removeUser/addLicense/removeLicense` posted to `/groups/:id/relationships/users|licenses`, which do not exist. They are rewritten to set the member's group (and clear it with `{ data: null }` to remove).

## 3. `/entitlements` is a flat resource with no sub-routes

[routes.rb#L375](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L375) — `resources :entitlements`, nothing nested.

So `entitlements.getLicenses()`, `attachToLicenses()` and `detachFromLicenses()` all 404. These are removed; the relationship is written from the other side (`licenses.attachEntitlements`, `policies.attachEntitlements`), which is documented in a note on the resource.

The entitlement **details dialog** rendered an "Associated Licenses" card fed by `getLicenses()` — so it was permanently empty, with the error swallowed. There is no way to obtain that list at all: `/licenses` has no entitlement filter ([`licenses_controller.rb` `has_scope` declarations](https://github.com/keygen-sh/keygen-api/blob/master/app/controllers/api/v1/licenses_controller.rb)). The card is replaced with a short explanation of how entitlements actually attach, rather than a list that can never populate.

---

## Testing

- `pnpm typecheck` and `pnpm lint` pass.
- Verified against a live Keygen CE 1.8 instance.

## Note

A separate PR fixes the webhook delivery list, which reads an `attributes.successful` field the API does not return (it returns `status` + `lastResponseCode`), causing every delivery to render as "Failed". It is held back because it depends on the webhook-events API added in the coverage PR.