### PR TITLE
fix(ui): dialog scrolling, duplicate select icons, scroll chaining

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - esbuild

--- a/src/components/entitlements/entitlement-management.tsx
+++ b/src/components/entitlements/entitlement-management.tsx
@@ -103,9 +103,14 @@ export function EntitlementManagement() {
             Manage feature entitlements and permissions for your products
           </p>
         </div>
-        <Button onClick={() => setCreateDialogOpen(true)} className="gap-2">
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button
+          onClick={() => setCreateDialogOpen(true)}
+          className="gap-2 max-sm:size-9 max-sm:px-0"
+          aria-label="Create Entitlement"
+        >
           <Plus className="h-4 w-4" />
-          Create Entitlement
+          <span className="max-sm:hidden">Create Entitlement</span>
         </Button>
       </div>
 

--- a/src/components/groups/group-details-dialog.tsx
+++ b/src/components/groups/group-details-dialog.tsx
@@ -73,7 +73,7 @@ export function GroupDetailsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Users className="h-5 w-5" />

--- a/src/components/groups/group-management.tsx
+++ b/src/components/groups/group-management.tsx
@@ -102,9 +102,14 @@ export function GroupManagement() {
             Organize users and licenses into groups for easier management
           </p>
         </div>
-        <Button onClick={() => setCreateDialogOpen(true)} className="gap-2">
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button
+          onClick={() => setCreateDialogOpen(true)}
+          className="gap-2 max-sm:size-9 max-sm:px-0"
+          aria-label="Create Group"
+        >
           <Plus className="h-4 w-4" />
-          Create Group
+          <span className="max-sm:hidden">Create Group</span>
         </Button>
       </div>
 

--- a/src/components/licenses/create-license-dialog.tsx
+++ b/src/components/licenses/create-license-dialog.tsx
@@ -6,6 +6,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -169,9 +170,10 @@ export function CreateLicenseDialog({ onLicenseCreated }: CreateLicenseDialogPro
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="mr-2 h-4 w-4" />
-          Create License
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button className="max-sm:size-9 max-sm:px-0" aria-label="Create License">
+          <Plus className="h-4 w-4 sm:mr-2" />
+          <span className="max-sm:hidden">Create License</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[720px]">
@@ -548,14 +550,14 @@ export function CreateLicenseDialog({ onLicenseCreated }: CreateLicenseDialogPro
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-2 pt-2">
+            <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setOpen(false)}>
                 Cancel
               </Button>
               <Button type="submit" disabled={loading}>
                 {loading ? 'Creating…' : 'Create License'}
               </Button>
-            </div>
+            </DialogFooter>
           </form>
         )}
       </DialogContent>

--- a/src/components/policies/create-policy-dialog.tsx
+++ b/src/components/policies/create-policy-dialog.tsx
@@ -183,12 +183,13 @@ export function CreatePolicyDialog({ onPolicyCreated }: CreatePolicyDialogProps)
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="mr-2 h-4 w-4" />
-          Create Policy
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button className="max-sm:size-9 max-sm:px-0" aria-label="Create Policy">
+          <Plus className="h-4 w-4 sm:mr-2" />
+          <span className="max-sm:hidden">Create Policy</span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[700px]">
         <DialogHeader>
           <DialogTitle>Create New Policy</DialogTitle>
           <DialogDescription>

--- a/src/components/products/create-product-dialog.tsx
+++ b/src/components/products/create-product-dialog.tsx
@@ -123,21 +123,13 @@ export function CreateProductDialog({ onProductCreated }: CreateProductDialogPro
     }
   }
 
-  const getStrategyIcon = (strategy: string) => {
-    switch (strategy) {
-      case 'LICENSED': return <Shield className="h-4 w-4" />
-      case 'OPEN': return <Unlock className="h-4 w-4" />
-      case 'CLOSED': return <Lock className="h-4 w-4" />
-      default: return <Shield className="h-4 w-4" />
-    }
-  }
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="mr-2 h-4 w-4" />
-          Create Product
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button className="max-sm:size-9 max-sm:px-0" aria-label="Create Product">
+          <Plus className="h-4 w-4 sm:mr-2" />
+          <span className="max-sm:hidden">Create Product</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[525px]">
@@ -180,7 +172,8 @@ export function CreateProductDialog({ onProductCreated }: CreateProductDialogPro
                 onValueChange={(value: 'LICENSED' | 'OPEN' | 'CLOSED') => setFormData({ ...formData, distributionStrategy: value })}
               >
                 <SelectTrigger>
-                  {getStrategyIcon(formData.distributionStrategy)}
+                  {/* SelectValue mirrors the chosen item, icon included — do not
+                      render the icon here as well. */}
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/products/edit-product-dialog.tsx
+++ b/src/components/products/edit-product-dialog.tsx
@@ -155,7 +155,7 @@ export function EditProductDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
           <DialogTitle>Edit Product</DialogTitle>
           <DialogDescription>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -60,7 +60,17 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          // Tall dialogs (create licence, release artifacts…) otherwise run off
+          // the top and bottom of the viewport with no way to reach their
+          // buttons: cap the height and scroll the body.
+          //
+          // flex, not grid: a grid item's containing block is its own cell, so a
+          // sticky footer inside a grid has no room to move and never sticks.
+          // When a footer is present it supplies the bottom padding itself, so
+          // drop the container's — otherwise it shows as a gap under the pinned
+          // footer (sticky pins the element's margin box, so a negative margin
+          // does not cancel the padding).
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 has-[[data-slot=dialog-footer]]:pb-0 sm:max-w-lg",
           className
         )}
         {...props}
@@ -95,7 +105,11 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        // Pinned to the bottom of the (scrolling) dialog so the actions stay
+        // reachable in long forms. -mx-6 bleeds it past the dialog's horizontal
+        // padding so the divider spans the full width; the container drops its
+        // bottom padding in favour of this element's own.
+        "sticky bottom-0 z-10 -mx-6 flex flex-col-reverse gap-2 border-t bg-background px-6 py-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -16,9 +16,11 @@ function ScrollArea({
       className={cn("relative", className)}
       {...props}
     >
+      {/* overscroll-contain: reaching the end of this list must not chain the
+          scroll on to whatever contains it (e.g. a scrolling dialog). */}
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full overscroll-contain rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/src/components/users/create-user-dialog.tsx
+++ b/src/components/users/create-user-dialog.tsx
@@ -113,16 +113,13 @@ export function CreateUserDialog({ onUserCreated }: CreateUserDialogProps) {
     })
   }
 
-  const getRoleIcon = (role: string) => {
-    return role === 'admin' ? <Shield className="h-4 w-4" /> : <User className="h-4 w-4" />
-  }
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
-          <Plus className="mr-2 h-4 w-4" />
-          Create User
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button className="max-sm:size-9 max-sm:px-0" aria-label="Create User">
+          <Plus className="h-4 w-4 sm:mr-2" />
+          <span className="max-sm:hidden">Create User</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[525px]">
@@ -152,7 +149,8 @@ export function CreateUserDialog({ onUserCreated }: CreateUserDialogProps) {
                 onValueChange={(value: typeof formData.role) => setFormData({ ...formData, role: value })}
               >
                 <SelectTrigger>
-                  {getRoleIcon(formData.role)}
+                  {/* SelectValue mirrors the chosen item, icon included — do not
+                      render the icon here as well. */}
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/webhooks/create-webhook-dialog.tsx
+++ b/src/components/webhooks/create-webhook-dialog.tsx
@@ -10,7 +10,6 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { toast } from 'sonner'
 import { handleFormError } from '@/lib/utils/error-handling'
@@ -112,7 +111,8 @@ export function CreateWebhookDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      {/* Height/scroll come from DialogContent itself, so the footer stays pinned. */}
+      <DialogContent className="max-w-4xl">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Create Webhook</DialogTitle>
@@ -165,8 +165,9 @@ export function CreateWebhookDialog({
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <ScrollArea className="h-96">
-                  <div className="space-y-4">
+                {/* No inner scroller: the dialog body scrolls, and nesting a
+                    second one made the list fight the dialog for the wheel. */}
+                <div className="space-y-4">
                     {Object.entries(eventGroups).map(([resource, events]) => (
                       <div key={resource} className="space-y-2">
                         <div className="flex items-center space-x-2">
@@ -192,13 +193,19 @@ export function CreateWebhookDialog({
                         </div>
                         <div className="ml-6 grid grid-cols-1 md:grid-cols-2 gap-2">
                           {events.map(event => (
-                            <div key={event} className="flex items-center space-x-2">
+                            <div key={event} className="flex items-start space-x-2">
                               <Checkbox
                                 id={event}
+                                className="mt-0.5 shrink-0"
                                 checked={formData.subscriptions.includes(event)}
                                 onCheckedChange={(checked) => handleEventToggle(event, checked as boolean)}
                               />
-                              <Label htmlFor={event} className="text-sm font-mono">
+                              {/* Event names are long unbroken tokens; let them wrap
+                                  instead of overflowing the column. */}
+                              <Label
+                                htmlFor={event}
+                                className="min-w-0 text-sm font-mono leading-snug break-all"
+                              >
                                 {event}
                               </Label>
                             </div>
@@ -209,8 +216,7 @@ export function CreateWebhookDialog({
                         )}
                       </div>
                     ))}
-                  </div>
-                </ScrollArea>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/src/components/webhooks/edit-webhook-dialog.tsx
+++ b/src/components/webhooks/edit-webhook-dialog.tsx
@@ -11,7 +11,6 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { toast } from 'sonner'
 import { handleCrudError } from '@/lib/utils/error-handling'
@@ -121,7 +120,7 @@ export function EditWebhookDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Edit Webhook</DialogTitle>
@@ -174,8 +173,9 @@ export function EditWebhookDialog({
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <ScrollArea className="h-96">
-                  <div className="space-y-4">
+                {/* No inner scroller: the dialog body scrolls, and nesting a
+                    second one made the list fight the dialog for the wheel. */}
+                <div className="space-y-4">
                     {Object.entries(eventGroups).map(([resource, events]) => (
                       <div key={resource} className="space-y-2">
                         <div className="flex items-center space-x-2">
@@ -201,13 +201,19 @@ export function EditWebhookDialog({
                         </div>
                         <div className="ml-6 grid grid-cols-1 md:grid-cols-2 gap-2">
                           {events.map(event => (
-                            <div key={event} className="flex items-center space-x-2">
+                            <div key={event} className="flex items-start space-x-2">
                               <Checkbox
                                 id={event}
+                                className="mt-0.5 shrink-0"
                                 checked={formData.subscriptions.includes(event)}
                                 onCheckedChange={(checked) => handleEventToggle(event, checked as boolean)}
                               />
-                              <Label htmlFor={event} className="text-sm font-mono">
+                              {/* Event names are long unbroken tokens; let them wrap
+                                  instead of overflowing the column. */}
+                              <Label
+                                htmlFor={event}
+                                className="min-w-0 text-sm font-mono leading-snug break-all"
+                              >
                                 {event}
                               </Label>
                             </div>
@@ -218,8 +224,7 @@ export function EditWebhookDialog({
                         )}
                       </div>
                     ))}
-                  </div>
-                </ScrollArea>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/src/components/webhooks/webhook-management.tsx
+++ b/src/components/webhooks/webhook-management.tsx
@@ -141,9 +141,14 @@ export function WebhookManagement() {
             Configure webhook endpoints to receive real-time event notifications
           </p>
         </div>
-        <Button onClick={() => setCreateDialogOpen(true)} className="gap-2">
+        {/* Icon-only on phones: the label pushes the header out of shape. */}
+        <Button
+          onClick={() => setCreateDialogOpen(true)}
+          className="gap-2 max-sm:size-9 max-sm:px-0"
+          aria-label="Create Webhook"
+        >
           <Plus className="h-4 w-4" />
-          Create Webhook
+          <span className="max-sm:hidden">Create Webhook</span>
         </Button>
       </div>
 


### PR DESCRIPTION
A handful of UI bugs found while using the dashboard against a live Keygen instance.

## 1. Tall dialogs run off the viewport with unreachable buttons

`DialogContent` had **no height cap**. The create-license dialog is ~560 lines of form; on a laptop its Cancel/Create buttons sit below the fold with no way to scroll to them. Create-policy and the webhook dialogs have the same problem.

It now caps at `100dvh - 2rem`, scrolls its body, and pins `DialogFooter` so the actions stay visible while the content scrolls.

Two subtleties worth knowing, since both cost me time:

- **`DialogContent` had to become a flex column.** A grid item's containing block is its own cell, so `position: sticky` inside a grid has nowhere to move — the footer could never stick, no matter what classes it carried.
- **The container's bottom padding shows as a gap under the pinned footer** (sticky pins the element's *margin box*, so a negative margin doesn't cancel it). `DialogContent` now drops its `pb` when a footer is present, via `has-[[data-slot=dialog-footer]]:pb-0`, and the footer supplies that spacing itself.

Per-dialog `max-h-[90vh] overflow-y-auto` overrides are removed in favour of the base — they duplicated it, used `vh` (wrong on mobile, where the browser chrome eats the viewport), and bypassed the footer rule.

`dvh` is used throughout for the same mobile reason.

## 2. Selects render their icon twice

The product **distribution strategy** and user **role** triggers rendered `getStrategyIcon(...)`/`getRoleIcon(...)` **and** `<SelectValue />` — but `SelectValue` mirrors the selected `SelectItem`, which already contains its own icon. Result: two shields. Removed the manual icon (and the now-unused helpers).

## 3. Nested scrollers chain their scroll to the dialog

Reaching the end of the webhook event list handed the remaining scroll to the dialog behind it, so the whole dialog started moving under you. Fixed at the primitive with `overscroll-contain` on the `ScrollArea` viewport. The nested scroller in the webhook dialogs is also removed — redundant now that the dialog body scrolls.

## 4. Webhook event names overflow instead of wrapping

`license.validation.succeeded` is a single unbroken token, and the `Label` is a flex item with `min-width: auto`, so it refused to shrink and overflowed its column. Now wraps (`min-w-0` + `break-all`), with the checkbox aligned to the first line.

## 5. Mobile: create buttons squeeze the page title

The page-header create buttons collapse to a plus icon below `sm`, keeping an `aria-label`. Above `sm` they are unchanged.

---

## Note on the pnpm fix

Includes the one-line `pnpm-workspace.yaml` fix from #23 so the branch installs standalone; it drops out on rebase once that lands.

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm build` pass.