### PR TITLE
feat(api): product tokens, license validation, webhook retry, and broader API coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
+    "radix-ui": "^1.6.2",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
@@ -60,5 +61,6 @@
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
-  }
+  },
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
+      radix-ui:
+        specifier: ^1.6.2
+        version: 1.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -741,11 +744,82 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
+  '@radix-ui/react-accessible-icon@1.1.11':
+    resolution: {integrity: sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.16':
+    resolution: {integrity: sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.19':
+    resolution: {integrity: sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.11':
+    resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.11':
+    resolution: {integrity: sha512-IUAhIVpBUvP5NNICjlaB1OFmtRLGqQqTF3ZOSGPoq3XeLXRFtHiWTRxSVEULgOd9GQR2c7tsYqDnhUennapZnw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -770,8 +844,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.2.2':
+    resolution: {integrity: sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.7':
+    resolution: {integrity: sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.16':
+    resolution: {integrity: sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -805,6 +931,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.3':
+    resolution: {integrity: sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -816,6 +964,15 @@ packages:
 
   '@radix-ui/react-context@1.1.3':
     resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -836,6 +993,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.19':
+    resolution: {integrity: sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -845,8 +1015,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.15':
+    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -871,6 +1063,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.20':
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -880,8 +1085,56 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.12':
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-form@0.1.12':
+    resolution: {integrity: sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.19':
+    resolution: {integrity: sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -900,6 +1153,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.11':
+    resolution: {integrity: sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-label@2.1.8':
@@ -928,6 +1203,71 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-menu@2.1.20':
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.20':
+    resolution: {integrity: sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.18':
+    resolution: {integrity: sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.12':
+    resolution: {integrity: sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.7':
+    resolution: {integrity: sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popover@1.1.15':
     resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
@@ -941,8 +1281,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.19':
+    resolution: {integrity: sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.3':
+    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.13':
+    resolution: {integrity: sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -980,6 +1359,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
@@ -1006,8 +1398,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.12':
+    resolution: {integrity: sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.4.3':
+    resolution: {integrity: sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.15':
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1032,6 +1476,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.14':
+    resolution: {integrity: sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
@@ -1045,8 +1502,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.3.3':
+    resolution: {integrity: sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.11':
+    resolution: {integrity: sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.4.3':
+    resolution: {integrity: sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1076,8 +1572,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.3':
+    resolution: {integrity: sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1102,6 +1620,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.17':
+    resolution: {integrity: sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.19':
+    resolution: {integrity: sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toggle-group@1.1.11':
     resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
     peerDependencies:
@@ -1115,8 +1659,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-toggle-group@1.1.15':
+    resolution: {integrity: sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.14':
+    resolution: {integrity: sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.15':
+    resolution: {integrity: sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.12':
+    resolution: {integrity: sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1150,8 +1746,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1168,8 +1782,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.3':
+    resolution: {integrity: sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1186,8 +1818,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1204,6 +1854,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -1213,8 +1872,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1235,8 +1912,24 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.7':
+    resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -2681,6 +3374,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.6.2:
+    resolution: {integrity: sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-day-picker@9.14.0:
     resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
     engines: {node: '>=18'}
@@ -3574,11 +4280,72 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/primitive@1.1.5': {}
+
+  '@radix-ui/react-accessible-icon@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-accordion@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-alert-dialog@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3598,6 +4365,19 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-avatar@1.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3608,6 +4388,50 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3632,6 +4456,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -3639,6 +4482,12 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -3666,7 +4515,35 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dialog@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -3679,6 +4556,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3700,11 +4590,43 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3717,12 +4639,59 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3759,6 +4728,108 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3774,6 +4845,29 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -3800,6 +4894,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3814,6 +4936,15 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3838,6 +4969,43 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3855,6 +5023,25 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -3866,6 +5053,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-scroll-area@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3901,9 +5105,67 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-select@2.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-separator@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slider@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3924,6 +5186,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3933,6 +5202,21 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-switch@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3955,6 +5239,42 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-tabs@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3970,11 +5290,72 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-toggle-group@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -4007,10 +5388,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -4022,9 +5417,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -4036,13 +5445,31 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -4055,9 +5482,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -4071,7 +5512,18 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/rect@1.1.1': {}
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -5616,6 +7068,69 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radix-ui@1.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-accessible-icon': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   react-day-picker@9.14.0(react@19.2.4):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - esbuild

--- a/src/app/(dashboard)/releases/page.tsx
+++ b/src/app/(dashboard)/releases/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedRoute } from "@/components/auth/protected-route"
+import { ReleaseManagement } from '@/components/releases/release-management'
+
+export default function ReleasesPage() {
+  return (
+    <ProtectedRoute>
+      <ReleaseManagement />
+    </ProtectedRoute>
+  )
+}

--- a/src/app/api/keygen/[...path]/route.ts
+++ b/src/app/api/keygen/[...path]/route.ts
@@ -77,6 +77,12 @@ async function proxyRequest(request: NextRequest, path: string[]) {
     'Accept': request.headers.get('accept') || 'application/vnd.api+json',
   }
 
+  // Forward Prefer (e.g. no-redirect / no-download for artifact presigned URLs)
+  const prefer = request.headers.get('prefer')
+  if (prefer) {
+    headers['Prefer'] = prefer
+  }
+
   // Forward auth header — prefer the request header (e.g. Basic auth during login),
   // otherwise fall back to the httpOnly session cookie.
   const authorization = request.headers.get('authorization')
@@ -106,15 +112,25 @@ async function proxyRequest(request: NextRequest, path: string[]) {
       headers,
       body: body || undefined,
       agent: targetUrl.startsWith('https') ? httpsAgent : undefined,
+      // Never follow upstream redirects — artifact endpoints respond with
+      // presigned storage URLs in the Location header (303/307), which the
+      // client must receive and use directly.
+      redirect: 'manual',
     })
 
     const data = await response.text()
 
+    const responseHeaders: Record<string, string> = {
+      'Content-Type': response.headers.get('content-type') || 'application/vnd.api+json',
+    }
+    const location = response.headers.get('location')
+    if (location) {
+      responseHeaders['Location'] = location
+    }
+
     return new NextResponse(data || null, {
       status: response.status,
-      headers: {
-        'Content-Type': response.headers.get('content-type') || 'application/vnd.api+json',
-      },
+      headers: responseHeaders,
     })
   } catch (error) {
     console.error('Proxy error:', error instanceof Error ? error.message : 'Unknown error')

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   IconUsersGroup,
   IconShieldCheck,
   IconWebhook,
+  IconRocket,
 } from "@tabler/icons-react"
 
 import { NavMain } from "@/components/nav-main"
@@ -48,6 +49,11 @@ const data = {
       title: "Products",
       url: "/products",
       icon: IconPackage,
+    },
+    {
+      title: "Releases",
+      url: "/releases",
+      icon: IconRocket,
     },
     {
       title: "Policies",

--- a/src/components/entitlements/entitlement-details-dialog.tsx
+++ b/src/components/entitlements/entitlement-details-dialog.tsx
@@ -1,15 +1,11 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { getKeygenApi } from '@/lib/api'
-import { Entitlement, License } from '@/lib/types/keygen'
+import { Entitlement } from '@/lib/types/keygen'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Shield, KeyRound, Calendar, Info, Code } from 'lucide-react'
 // toast not needed; using centralized error handlers
-import { handleLoadError } from '@/lib/utils/error-handling'
 
 interface EntitlementDetailsDialogProps {
   entitlement: Entitlement
@@ -22,32 +18,6 @@ export function EntitlementDetailsDialog({
   open,
   onOpenChange
 }: EntitlementDetailsDialogProps) {
-  const [licenses, setLicenses] = useState<License[]>([])
-  const [loadingLicenses, setLoadingLicenses] = useState(false)
-  
-  const api = getKeygenApi()
-
-  const loadEntitlementDetails = useCallback(async () => {
-    if (!entitlement.id) return
-
-    // Load associated licenses
-    setLoadingLicenses(true)
-    try {
-      const licensesResponse = await api.entitlements.getLicenses(entitlement.id, { limit: 10 })
-      setLicenses((licensesResponse.data as License[]) || [])
-    } catch (error: unknown) {
-      handleLoadError(error, 'entitlement licenses')
-    } finally {
-      setLoadingLicenses(false)
-    }
-  }, [api.entitlements, entitlement.id])
-
-  useEffect(() => {
-    if (open && entitlement.id) {
-      loadEntitlementDetails()
-    }
-  }, [open, entitlement.id, loadEntitlementDetails])
-
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -121,71 +91,27 @@ export function EntitlementDetailsDialog({
             </CardContent>
           </Card>
 
-          {/* Associated Licenses */}
+          {/* Where this entitlement is used.
+
+              Keygen has no endpoint for "which licences carry this entitlement"
+              — /entitlements is a flat resource and /licenses has no entitlement
+              filter — so this explains the relationship rather than faking a list. */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <KeyRound className="h-4 w-4" />
-                Associated Licenses ({licenses.length})
+                Where it applies
               </CardTitle>
               <CardDescription>
-                Licenses that have this entitlement enabled (showing first 10)
+                Entitlements are attached to licences and policies, not the other way round
               </CardDescription>
             </CardHeader>
             <CardContent>
-              {loadingLicenses ? (
-                <div className="space-y-2">
-                  {[...Array(3)].map((_, i) => (
-                    <Skeleton key={i} className="h-8 w-full" />
-                  ))}
-                </div>
-              ) : licenses.length > 0 ? (
-                <div className="space-y-2">
-                  {licenses.map((license) => (
-                    <div key={license.id} className="flex items-center justify-between p-3 border rounded">
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">
-                          {license.attributes.name || 'Unnamed License'}
-                        </p>
-                        <p className="text-xs text-muted-foreground font-mono">
-                          {license.attributes.key}
-                        </p>
-                        <div className="flex items-center gap-2">
-                          <Badge variant={license.attributes.status === 'active' ? 'default' : 'secondary'}>
-                            {license.attributes.status}
-                          </Badge>
-                          {license.attributes.uses !== undefined && (
-                            <Badge variant="outline">
-                              Uses: {license.attributes.uses}
-                              {license.attributes.maxUses ? `/${license.attributes.maxUses}` : ''}
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-xs text-muted-foreground">
-                          Created: {new Date(license.attributes.created).toLocaleDateString()}
-                        </p>
-                        {license.attributes.expiry && (
-                          <p className="text-xs text-muted-foreground">
-                            Expires: {new Date(license.attributes.expiry).toLocaleDateString()}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-8">
-                  <Shield className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-                  <p className="text-sm text-muted-foreground">
-                    No licenses are currently using this entitlement
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Licenses with this entitlement will appear here
-                  </p>
-                </div>
-              )}
+              <p className="text-muted-foreground text-sm">
+                Attach this entitlement to a <strong>policy</strong> to grant it to every
+                licence under that policy, or to an individual <strong>licence</strong> for
+                a one-off. Do that from the policy or licence itself.
+              </p>
             </CardContent>
           </Card>
 

--- a/src/components/licenses/license-management.tsx
+++ b/src/components/licenses/license-management.tsx
@@ -51,6 +51,7 @@ import {
   ChevronsRight,
   X,
   Loader2,
+  BadgeCheck,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { handleLoadError, handleCrudError } from '@/lib/utils/error-handling'
@@ -212,6 +213,28 @@ export function LicenseManagement() {
     })
   }
 
+  /**
+   * Asks the server whether the licence is usable right now, and shows why not
+   * if it isn't (EXPIRED, SUSPENDED, TOO_MANY_MACHINES, …). The status column
+   * alone does not explain, say, an active licence that has used up its seats.
+   */
+  const handleValidateLicense = async (license: License) => {
+    try {
+      const result = await api.licenses.validate(license.id)
+      const meta = result.meta
+
+      if (meta?.valid) {
+        toast.success(`Valid — ${meta.detail}`)
+      } else {
+        toast.warning(`Not valid — ${meta?.detail ?? 'unknown reason'}`, {
+          description: meta?.code,
+        })
+      }
+    } catch (error: unknown) {
+      handleCrudError(error, 'update', 'License', { customMessage: 'Failed to validate license' })
+    }
+  }
+
   const handleSuspendLicense = async (license: License) => {
     try {
       await api.licenses.suspend(license.id)
@@ -318,9 +341,9 @@ export function LicenseManagement() {
       </div>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Licenses</CardTitle>
             <Key className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -332,7 +355,7 @@ export function LicenseManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Active</CardTitle>
             <Activity className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -342,7 +365,7 @@ export function LicenseManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Expired</CardTitle>
             <Calendar className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -352,7 +375,7 @@ export function LicenseManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Usage</CardTitle>
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -364,8 +387,8 @@ export function LicenseManagement() {
       </div>
 
       {/* Search and Filters */}
-      <div className="flex items-center gap-3">
-        <div className="relative flex-1 max-w-md">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative basis-full sm:basis-auto flex-1 sm:max-w-md">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             ref={searchInputRef}
@@ -396,7 +419,7 @@ export function LicenseManagement() {
           )}
         </div>
         <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger className="w-[150px]">
+          <SelectTrigger className="min-w-0 flex-1 sm:w-[150px] sm:flex-none">
             <Filter className="mr-2 h-4 w-4" />
             <SelectValue placeholder="Filter by status" />
           </SelectTrigger>
@@ -523,6 +546,10 @@ export function LicenseManagement() {
                           <DropdownMenuItem onClick={() => handleEditLicense(license)}>
                             <Edit className="mr-2 h-4 w-4" />
                             Edit License
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleValidateLicense(license)}>
+                            <BadgeCheck className="mr-2 h-4 w-4" />
+                            Validate
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => handleGenerateToken(license)}>
                             <Download className="mr-2 h-4 w-4" />

--- a/src/components/products/product-management.tsx
+++ b/src/components/products/product-management.tsx
@@ -41,12 +41,14 @@ import {
   Edit,
   Trash2,
   ExternalLink,
+  KeyRound,
 } from 'lucide-react'
 // No direct toasts here; using centralized error handlers where needed
 import { handleLoadError } from '@/lib/utils/error-handling'
 import { CreateProductDialog } from './create-product-dialog'
 import { EditProductDialog } from './edit-product-dialog'
 import { DeleteProductDialog } from './delete-product-dialog'
+import { ProductTokensDialog } from './product-tokens-dialog'
 
 export function ProductManagement() {
   const [products, setProducts] = useState<Product[]>([])
@@ -57,6 +59,8 @@ export function ProductManagement() {
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [deleteProduct, setDeleteProduct] = useState<Product | null>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [tokensProduct, setTokensProduct] = useState<Product | null>(null)
+  const [tokensDialogOpen, setTokensDialogOpen] = useState(false)
   const api = getKeygenApi()
 
   const loadProducts = useCallback(async () => {
@@ -129,6 +133,11 @@ export function ProductManagement() {
     }
   }
 
+  const handleTokens = (product: Product) => {
+    setTokensProduct(product)
+    setTokensDialogOpen(true)
+  }
+
   const handleEditProduct = (product: Product) => {
     setEditProduct(product)
     setEditDialogOpen(true)
@@ -148,9 +157,9 @@ export function ProductManagement() {
       </div>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Products</CardTitle>
             <Package className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -162,7 +171,7 @@ export function ProductManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Licensed</CardTitle>
             <Shield className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -176,7 +185,7 @@ export function ProductManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Open</CardTitle>
             <Unlock className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -190,7 +199,7 @@ export function ProductManagement() {
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex min-h-[3.25rem] flex-row items-start justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Closed</CardTitle>
             <Lock className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -206,8 +215,8 @@ export function ProductManagement() {
       </div>
 
       {/* Filters and Search */}
-      <div className="flex items-center space-x-4">
-        <div className="flex-1 max-w-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="basis-full sm:basis-auto flex-1 sm:max-w-sm">
           <div className="relative">
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
@@ -219,7 +228,7 @@ export function ProductManagement() {
           </div>
         </div>
         <Select value={strategyFilter} onValueChange={setStrategyFilter}>
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="min-w-0 flex-1 sm:w-[180px] sm:flex-none">
             <Filter className="mr-2 h-4 w-4" />
             <SelectValue placeholder="Filter by strategy" />
           </SelectTrigger>
@@ -332,6 +341,10 @@ export function ProductManagement() {
                             <Edit className="mr-2 h-4 w-4" />
                             Edit Product
                           </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleTokens(product)}>
+                            <KeyRound className="mr-2 h-4 w-4" />
+                            Tokens
+                          </DropdownMenuItem>
                           {product.attributes.url && (
                             <DropdownMenuItem onClick={() => openUrl(product.attributes.url!)}>
                               <ExternalLink className="mr-2 h-4 w-4" />
@@ -381,6 +394,12 @@ export function ProductManagement() {
       />
 
       {/* Delete Product Dialog */}
+      <ProductTokensDialog
+        product={tokensProduct}
+        open={tokensDialogOpen}
+        onOpenChange={setTokensDialogOpen}
+      />
+
       <DeleteProductDialog
         product={deleteProduct}
         open={deleteDialogOpen}

--- a/src/components/products/product-tokens-dialog.tsx
+++ b/src/components/products/product-tokens-dialog.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Copy, KeyRound, Loader2, ShieldAlert } from 'lucide-react'
+import { getKeygenApi } from '@/lib/api'
+import { Product, Token } from '@/lib/types/keygen'
+import { toast } from 'sonner'
+import { handleCrudError, handleLoadError } from '@/lib/utils/error-handling'
+
+interface ProductTokensDialogProps {
+  product: Product | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Product-scoped API tokens.
+ *
+ * These are what a build pipeline should use to publish releases: a product
+ * token can only act on this product, so a leaked CI secret cannot touch
+ * licences or other products the way an admin token could.
+ */
+export function ProductTokensDialog({ product, open, onOpenChange }: ProductTokensDialogProps) {
+  const [tokens, setTokens] = useState<Token[]>([])
+  const [loading, setLoading] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [name, setName] = useState('')
+  const [newSecret, setNewSecret] = useState<string | null>(null)
+  const api = getKeygenApi()
+
+  const loadTokens = useCallback(async () => {
+    if (!product) return
+    try {
+      setLoading(true)
+      const response = await api.products.listTokens(product.id)
+      setTokens(response.data || [])
+    } catch (error: unknown) {
+      handleLoadError(error, 'tokens')
+    } finally {
+      setLoading(false)
+    }
+  }, [api.products, product])
+
+  useEffect(() => {
+    if (open && product) {
+      setNewSecret(null)
+      setName('')
+      loadTokens()
+    }
+  }, [open, product, loadTokens])
+
+  const handleCreate = async () => {
+    if (!product) return
+
+    try {
+      setCreating(true)
+      const response = await api.products.createToken(product.id, {
+        name: name.trim() || undefined,
+      })
+
+      // The secret is only ever present on this response — never readable again.
+      const secret = response.data?.attributes.token
+      if (secret) {
+        setNewSecret(secret)
+        toast.success('Token created — copy it now')
+      }
+      setName('')
+      loadTokens()
+    } catch (error: unknown) {
+      handleCrudError(error, 'create', 'token')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const copySecret = async () => {
+    if (!newSecret) return
+    await navigator.clipboard.writeText(newSecret)
+    toast.success('Copied to clipboard')
+  }
+
+  const formatDate = (value?: string) => (value ? new Date(value).toLocaleString() : '—')
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[640px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5" />
+            Product Tokens
+            {product && (
+              <span className="text-muted-foreground text-sm font-normal">
+                {product.attributes.name}
+              </span>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            Scoped to this product only — use one of these in CI to publish releases,
+            rather than an admin token.
+          </DialogDescription>
+        </DialogHeader>
+
+        {newSecret && (
+          <Alert>
+            <ShieldAlert className="h-4 w-4" />
+            <AlertTitle>Copy this token now</AlertTitle>
+            <AlertDescription>
+              <div className="space-y-2">
+                <p className="text-xs">It will not be shown again.</p>
+                <div className="flex items-center gap-2">
+                  <code className="bg-muted min-w-0 flex-1 truncate rounded px-2 py-1 font-mono text-xs">
+                    {newSecret}
+                  </code>
+                  <Button size="sm" variant="outline" onClick={copySecret}>
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex items-end gap-2">
+          <div className="grid flex-1 gap-2">
+            <Label htmlFor="token-name">Name</Label>
+            <Input
+              id="token-name"
+              placeholder="e.g. CI release pipeline"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={creating}
+            />
+          </div>
+          <Button onClick={handleCreate} disabled={creating}>
+            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Create token'}
+          </Button>
+        </div>
+
+        {loading && tokens.length === 0 ? (
+          <div className="text-muted-foreground flex h-20 items-center justify-center text-sm">
+            Loading tokens...
+          </div>
+        ) : tokens.length === 0 ? (
+          <div className="text-muted-foreground flex h-20 items-center justify-center text-xs">
+            No tokens yet
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Expires</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tokens.map((token) => (
+                <TableRow key={token.id}>
+                  <TableCell>
+                    {token.attributes.name || (
+                      <span className="text-muted-foreground">Unnamed</span>
+                    )}
+                  </TableCell>
+                  <TableCell>{formatDate(token.attributes.created)}</TableCell>
+                  <TableCell>
+                    {token.attributes.expiry ? formatDate(token.attributes.expiry) : 'Never'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/releases/create-release-dialog.tsx
+++ b/src/components/releases/create-release-dialog.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { Plus } from 'lucide-react'
+import { getKeygenApi } from '@/lib/api'
+import { Product, ReleaseChannel } from '@/lib/types/keygen'
+import { toast } from 'sonner'
+import { handleFormError } from '@/lib/utils/error-handling'
+
+interface CreateReleaseDialogProps {
+  products: Product[]
+  onReleaseCreated?: () => void
+}
+
+export function CreateReleaseDialog({ products, onReleaseCreated }: CreateReleaseDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    productId: '',
+    version: '',
+    channel: 'stable' as ReleaseChannel,
+    name: '',
+    tag: '',
+    description: '',
+  })
+
+  const api = getKeygenApi()
+
+  const resetForm = () => {
+    setFormData({
+      productId: '',
+      version: '',
+      channel: 'stable',
+      name: '',
+      tag: '',
+      description: '',
+    })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!formData.productId) {
+      toast.error('Please select a product')
+      return
+    }
+    if (!formData.version.trim()) {
+      toast.error('Please enter a version (semver, e.g. 1.2.3)')
+      return
+    }
+
+    try {
+      setLoading(true)
+
+      await api.releases.create({
+        productId: formData.productId,
+        version: formData.version.trim(),
+        channel: formData.channel,
+        name: formData.name.trim() || undefined,
+        tag: formData.tag.trim() || undefined,
+        description: formData.description.trim() || undefined,
+      })
+
+      toast.success(`Release ${formData.version} created as draft`)
+      resetForm()
+      setOpen(false)
+      onReleaseCreated?.()
+    } catch (error: unknown) {
+      handleFormError(error, 'release')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Release
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[480px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Release</DialogTitle>
+            <DialogDescription>
+              Releases are created as drafts. Upload artifacts, then publish to make it downloadable.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="product">Product *</Label>
+              <Select
+                value={formData.productId}
+                onValueChange={(value) => setFormData({ ...formData, productId: value })}
+              >
+                <SelectTrigger id="product">
+                  <SelectValue placeholder="Select a product" />
+                </SelectTrigger>
+                <SelectContent>
+                  {products.map(product => (
+                    <SelectItem key={product.id} value={product.id}>
+                      {product.attributes.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="version">Version *</Label>
+                <Input
+                  id="version"
+                  placeholder="1.0.0"
+                  value={formData.version}
+                  onChange={(e) => setFormData({ ...formData, version: e.target.value })}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="channel">Channel *</Label>
+                <Select
+                  value={formData.channel}
+                  onValueChange={(value) => setFormData({ ...formData, channel: value as ReleaseChannel })}
+                >
+                  <SelectTrigger id="channel">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="stable">Stable</SelectItem>
+                    <SelectItem value="rc">RC</SelectItem>
+                    <SelectItem value="beta">Beta</SelectItem>
+                    <SelectItem value="alpha">Alpha</SelectItem>
+                    <SelectItem value="dev">Dev</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                placeholder="e.g. My App 1.0.0"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="tag">Tag</Label>
+              <Input
+                id="tag"
+                placeholder="e.g. latest"
+                value={formData.tag}
+                onChange={(e) => setFormData({ ...formData, tag: e.target.value })}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                placeholder="Release notes or changelog..."
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={loading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Creating...' : 'Create Draft'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/releases/delete-release-dialog.tsx
+++ b/src/components/releases/delete-release-dialog.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { getKeygenApi } from '@/lib/api'
+import { Release } from '@/lib/types/keygen'
+import { toast } from 'sonner'
+import { handleCrudError } from '@/lib/utils/error-handling'
+import { AlertTriangle } from 'lucide-react'
+
+interface DeleteReleaseDialogProps {
+  release: Release | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onReleaseDeleted?: () => void
+}
+
+export function DeleteReleaseDialog({ release, open, onOpenChange, onReleaseDeleted }: DeleteReleaseDialogProps) {
+  const [loading, setLoading] = useState(false)
+  const api = getKeygenApi()
+
+  const handleDelete = async () => {
+    if (!release) return
+
+    try {
+      setLoading(true)
+      await api.releases.delete(release.id)
+      toast.success(`Release ${release.attributes.version} deleted`)
+      onOpenChange(false)
+      onReleaseDeleted?.()
+    } catch (error: unknown) {
+      handleCrudError(error, 'delete', 'release', {
+        onNotFound: () => {
+          onOpenChange(false)
+          onReleaseDeleted?.()
+        },
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            Delete Release
+          </DialogTitle>
+          <DialogDescription>
+            This permanently deletes release{' '}
+            <code className="px-1 py-0.5 bg-muted rounded text-xs font-mono">
+              {release?.attributes.version}
+            </code>{' '}
+            and all of its artifacts. Licensed clients will no longer be able to
+            download this version. If you only want to revoke access, yank the
+            release instead.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? 'Deleting...' : 'Delete Release'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/releases/edit-release-dialog.tsx
+++ b/src/components/releases/edit-release-dialog.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { getKeygenApi } from '@/lib/api'
+import { Release } from '@/lib/types/keygen'
+import { toast } from 'sonner'
+import { handleFormError } from '@/lib/utils/error-handling'
+
+interface EditReleaseDialogProps {
+  release: Release | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onReleaseUpdated?: () => void
+}
+
+export function EditReleaseDialog({ release, open, onOpenChange, onReleaseUpdated }: EditReleaseDialogProps) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    tag: '',
+    description: '',
+  })
+
+  const api = getKeygenApi()
+
+  useEffect(() => {
+    if (release) {
+      setFormData({
+        name: release.attributes.name || '',
+        tag: release.attributes.tag || '',
+        description: release.attributes.description || '',
+      })
+    }
+  }, [release])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!release) return
+
+    try {
+      setLoading(true)
+
+      await api.releases.update(release.id, {
+        name: formData.name.trim() || null,
+        tag: formData.tag.trim() || null,
+        description: formData.description.trim() || null,
+      })
+
+      toast.success('Release updated')
+      onOpenChange(false)
+      onReleaseUpdated?.()
+    } catch (error: unknown) {
+      handleFormError(error, 'release')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Edit Release</DialogTitle>
+            <DialogDescription>
+              {release ? `Version ${release.attributes.version} (${release.attributes.channel})` : ''}
+              {' — '}version and channel cannot be changed after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="edit-name">Name</Label>
+              <Input
+                id="edit-name"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-tag">Tag</Label>
+              <Input
+                id="edit-tag"
+                value={formData.tag}
+                onChange={(e) => setFormData({ ...formData, tag: e.target.value })}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-description">Description</Label>
+              <Textarea
+                id="edit-description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/releases/release-artifacts-dialog.tsx
+++ b/src/components/releases/release-artifacts-dialog.tsx
@@ -1,0 +1,415 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import { Upload, Download, Trash2, FileArchive, Loader2, RefreshCw } from 'lucide-react'
+import { getKeygenApi } from '@/lib/api'
+import { Release, ReleaseArtifact, ArtifactStatus } from '@/lib/types/keygen'
+import { toast } from 'sonner'
+import { handleLoadError, handleCrudError } from '@/lib/utils/error-handling'
+
+interface ReleaseArtifactsDialogProps {
+  release: Release | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const PLATFORMS = ['windows', 'darwin', 'linux'] as const
+const ARCHES = ['x86_64', 'amd64', 'arm64', '386'] as const
+
+export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseArtifactsDialogProps) {
+  const [artifacts, setArtifacts] = useState<ReleaseArtifact[]>([])
+  const [loading, setLoading] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const [platform, setPlatform] = useState<string>('none')
+  const [arch, setArch] = useState<string>('none')
+  const [uploading, setUploading] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState(0)
+  const [processingIds, setProcessingIds] = useState<Set<string>>(new Set())
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const pollTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const api = getKeygenApi()
+
+  const loadArtifacts = useCallback(async () => {
+    if (!release) return
+    try {
+      setLoading(true)
+      const response = await api.releases.listArtifacts(release.id)
+      setArtifacts(response.data || [])
+    } catch (error: unknown) {
+      handleLoadError(error, 'artifacts')
+    } finally {
+      setLoading(false)
+    }
+  }, [api.releases, release])
+
+  useEffect(() => {
+    if (open && release) {
+      loadArtifacts()
+    }
+  }, [open, release, loadArtifacts])
+
+  // Clear poll timers when the dialog closes or unmounts
+  useEffect(() => {
+    const timers = pollTimersRef.current
+    if (!open) {
+      timers.forEach(timer => clearTimeout(timer))
+      timers.clear()
+      setProcessingIds(new Set())
+    }
+    return () => {
+      timers.forEach(timer => clearTimeout(timer))
+      timers.clear()
+    }
+  }, [open])
+
+  /**
+   * Poll a freshly uploaded artifact until the server-side worker marks it
+   * UPLOADED (it checks storage every ~30s, so this can take a minute).
+   */
+  const pollArtifactStatus = useCallback((artifactId: string, attempts = 0) => {
+    if (attempts > 24) { // ~2 minutes
+      setProcessingIds(prev => {
+        const next = new Set(prev)
+        next.delete(artifactId)
+        return next
+      })
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      pollTimersRef.current.delete(artifactId)
+      try {
+        const response = await api.artifacts.get(artifactId)
+        const status = response.data?.attributes.status
+
+        if (status === 'UPLOADED' || status === 'FAILED') {
+          setProcessingIds(prev => {
+            const next = new Set(prev)
+            next.delete(artifactId)
+            return next
+          })
+          if (status === 'UPLOADED') {
+            toast.success('Artifact processed and ready for download')
+          } else {
+            toast.error('Artifact processing failed')
+          }
+          loadArtifacts()
+          return
+        }
+      } catch {
+        // Transient polling error — keep trying
+      }
+      pollArtifactStatus(artifactId, attempts + 1)
+    }, 5000)
+
+    pollTimersRef.current.set(artifactId, timer)
+  }, [api.artifacts, loadArtifacts])
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0] || null
+    setFile(selected)
+
+    // Best-effort platform guess from the filename
+    if (selected) {
+      const name = selected.name.toLowerCase()
+      if (name.endsWith('.exe') || name.endsWith('.msi') || name.includes('windows') || name.includes('win')) {
+        setPlatform('windows')
+      } else if (name.endsWith('.dmg') || name.endsWith('.pkg') || name.includes('darwin') || name.includes('mac')) {
+        setPlatform('darwin')
+      } else if (name.endsWith('.appimage') || name.endsWith('.deb') || name.endsWith('.rpm') || name.includes('linux')) {
+        setPlatform('linux')
+      }
+    }
+  }
+
+  const handleUpload = async () => {
+    if (!release || !file) {
+      toast.error('Please choose a file to upload')
+      return
+    }
+
+    try {
+      setUploading(true)
+      setUploadProgress(0)
+
+      const filetype = file.name.includes('.')
+        ? file.name.split('.').pop()
+        : undefined
+
+      const { artifact, uploadUrl } = await api.artifacts.create({
+        releaseId: release.id,
+        filename: file.name,
+        filesize: file.size,
+        filetype,
+        platform: platform !== 'none' ? platform : undefined,
+        arch: arch !== 'none' ? arch : undefined,
+      })
+
+      await api.artifacts.uploadFile(uploadUrl, file, setUploadProgress)
+
+      toast.success('Upload complete — processing on server (can take ~1 min)')
+      setFile(null)
+      setPlatform('none')
+      setArch('none')
+      if (fileInputRef.current) fileInputRef.current.value = ''
+
+      setProcessingIds(prev => new Set(prev).add(artifact.id))
+      pollArtifactStatus(artifact.id)
+      loadArtifacts()
+    } catch (error: unknown) {
+      handleCrudError(error, 'create', 'artifact', {
+        customMessage: error instanceof Error ? error.message : undefined,
+      })
+    } finally {
+      setUploading(false)
+      setUploadProgress(0)
+    }
+  }
+
+  const handleDownload = async (artifact: ReleaseArtifact) => {
+    try {
+      const url = await api.artifacts.getDownloadUrl(artifact.id)
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } catch (error: unknown) {
+      handleLoadError(error, 'download URL', {
+        customMessage: 'Could not get download URL — the artifact may still be processing',
+      })
+    }
+  }
+
+  const handleDelete = async (artifact: ReleaseArtifact) => {
+    try {
+      await api.artifacts.delete(artifact.id)
+      toast.success(`Artifact ${artifact.attributes.filename} deleted`)
+      loadArtifacts()
+    } catch (error: unknown) {
+      handleCrudError(error, 'delete', 'artifact')
+    }
+  }
+
+  const getStatusBadge = (artifact: ReleaseArtifact) => {
+    const status = artifact.attributes.status
+    const isPolling = processingIds.has(artifact.id)
+    const colorFor = (s: ArtifactStatus) => {
+      switch (s) {
+        case 'UPLOADED': return 'bg-green-100 text-green-800 border-green-200'
+        case 'WAITING': return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+        case 'PROCESSING': return 'bg-blue-100 text-blue-800 border-blue-200'
+        case 'FAILED': return 'bg-red-100 text-red-800 border-red-200'
+        case 'YANKED': return 'bg-red-100 text-red-800 border-red-200'
+        default: return 'bg-gray-100 text-gray-800 border-gray-200'
+      }
+    }
+    return (
+      <Badge variant="outline" className={`${colorFor(status)} flex items-center gap-1 w-fit`}>
+        {(isPolling || status === 'PROCESSING') && <Loader2 className="h-3 w-3 animate-spin" />}
+        {status.toLowerCase()}
+      </Badge>
+    )
+  }
+
+  const formatBytes = (bytes?: number | null) => {
+    if (!bytes) return '—'
+    const units = ['B', 'KB', 'MB', 'GB']
+    let value = bytes
+    let unit = 0
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024
+      unit++
+    }
+    return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[760px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileArchive className="h-5 w-5" />
+            Artifacts
+            {release && (
+              <code className="px-2 py-1 bg-muted rounded text-xs font-mono">
+                {release.attributes.version}
+              </code>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            Upload the build files for this release. Files go directly to your storage
+            server; processing after upload can take about a minute.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Upload form */}
+        <div className="rounded-lg border p-4 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid gap-2 md:col-span-1">
+              <Label htmlFor="artifact-file">File</Label>
+              <Input
+                id="artifact-file"
+                type="file"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                disabled={uploading}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="artifact-platform">Platform</Label>
+              <Select value={platform} onValueChange={setPlatform} disabled={uploading}>
+                <SelectTrigger id="artifact-platform">
+                  <SelectValue placeholder="Optional" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Not set</SelectItem>
+                  {PLATFORMS.map(p => (
+                    <SelectItem key={p} value={p}>{p}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="artifact-arch">Architecture</Label>
+              <Select value={arch} onValueChange={setArch} disabled={uploading}>
+                <SelectTrigger id="artifact-arch">
+                  <SelectValue placeholder="Optional" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Not set</SelectItem>
+                  {ARCHES.map(a => (
+                    <SelectItem key={a} value={a}>{a}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {uploading && (
+            <div className="space-y-1">
+              <Progress value={uploadProgress} />
+              <p className="text-xs text-muted-foreground text-right">{uploadProgress}%</p>
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button onClick={handleUpload} disabled={!file || uploading}>
+              {uploading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Uploading...
+                </>
+              ) : (
+                <>
+                  <Upload className="mr-2 h-4 w-4" />
+                  Upload Artifact
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Artifact list */}
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            {artifacts.length} artifact{artifacts.length === 1 ? '' : 's'}
+          </p>
+          <Button variant="ghost" size="sm" onClick={loadArtifacts} disabled={loading}>
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+
+        {loading && artifacts.length === 0 ? (
+          <div className="flex items-center justify-center h-24">
+            <div className="text-sm text-muted-foreground">Loading artifacts...</div>
+          </div>
+        ) : artifacts.length === 0 ? (
+          <div className="flex items-center justify-center h-24">
+            <div className="text-center">
+              <FileArchive className="mx-auto h-6 w-6 text-muted-foreground mb-1" />
+              <div className="text-xs text-muted-foreground">
+                No artifacts yet — upload the first build above
+              </div>
+            </div>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Filename</TableHead>
+                <TableHead>Platform</TableHead>
+                <TableHead>Arch</TableHead>
+                <TableHead>Size</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-[90px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {artifacts.map((artifact) => (
+                <TableRow key={artifact.id}>
+                  <TableCell>
+                    <code className="text-xs font-mono">{artifact.attributes.filename}</code>
+                  </TableCell>
+                  <TableCell>
+                    {artifact.attributes.platform || <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                  <TableCell>
+                    {artifact.attributes.arch || <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                  <TableCell>{formatBytes(artifact.attributes.filesize)}</TableCell>
+                  <TableCell>{getStatusBadge(artifact)}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDownload(artifact)}
+                        disabled={artifact.attributes.status !== 'UPLOADED'}
+                        title="Download"
+                      >
+                        <Download className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => handleDelete(artifact)}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/releases/release-artifacts-dialog.tsx
+++ b/src/components/releases/release-artifacts-dialog.tsx
@@ -40,8 +40,10 @@ interface ReleaseArtifactsDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-const PLATFORMS = ['windows', 'darwin', 'linux'] as const
-const ARCHES = ['x86_64', 'amd64', 'arm64', '386'] as const
+// Fallbacks only: the real lists come from the server (Keygen derives them from
+// the artifacts already uploaded), so the dropdowns match what you actually ship.
+const FALLBACK_PLATFORMS = ['windows', 'darwin', 'linux']
+const FALLBACK_ARCHES = ['x86_64', 'amd64', 'arm64', '386']
 
 export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseArtifactsDialogProps) {
   const [artifacts, setArtifacts] = useState<ReleaseArtifact[]>([])
@@ -52,6 +54,8 @@ export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseA
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [processingIds, setProcessingIds] = useState<Set<string>>(new Set())
+  const [platforms, setPlatforms] = useState<string[]>(FALLBACK_PLATFORMS)
+  const [arches, setArches] = useState<string[]>(FALLBACK_ARCHES)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const pollTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const api = getKeygenApi()
@@ -74,6 +78,29 @@ export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseA
       loadArtifacts()
     }
   }, [open, release, loadArtifacts])
+
+  // Known platforms/arches, so the dropdowns reflect what has really been
+  // published rather than a hardcoded guess. Falls back if the call fails.
+  useEffect(() => {
+    if (!open) return
+
+    ;(async () => {
+      try {
+        const [platformsResponse, archesResponse] = await Promise.all([
+          api.releaseMetadata.platforms(),
+          api.releaseMetadata.arches(),
+        ])
+
+        const platformKeys = (platformsResponse.data || []).map(p => p.attributes.key)
+        const archKeys = (archesResponse.data || []).map(a => a.attributes.key)
+
+        if (platformKeys.length) setPlatforms(platformKeys)
+        if (archKeys.length) setArches(archKeys)
+      } catch {
+        // Keep the fallbacks — this is a convenience, not a requirement.
+      }
+    })()
+  }, [open, api.releaseMetadata])
 
   // Clear poll timers when the dialog closes or unmounts
   useEffect(() => {
@@ -287,7 +314,7 @@ export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseA
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="none">Not set</SelectItem>
-                  {PLATFORMS.map(p => (
+                  {platforms.map(p => (
                     <SelectItem key={p} value={p}>{p}</SelectItem>
                   ))}
                 </SelectContent>
@@ -301,7 +328,7 @@ export function ReleaseArtifactsDialog({ release, open, onOpenChange }: ReleaseA
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="none">Not set</SelectItem>
-                  {ARCHES.map(a => (
+                  {arches.map(a => (
                     <SelectItem key={a} value={a}>{a}</SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/releases/release-management.tsx
+++ b/src/components/releases/release-management.tsx
@@ -1,0 +1,423 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { getKeygenApi } from '@/lib/api'
+import { Release, Product, ReleaseStatus } from '@/lib/types/keygen'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Search,
+  Filter,
+  MoreVertical,
+  Rocket,
+  Upload,
+  Edit,
+  Trash2,
+  Send,
+  Ban,
+  FileArchive,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { handleLoadError, handleCrudError } from '@/lib/utils/error-handling'
+import { CreateReleaseDialog } from './create-release-dialog'
+import { EditReleaseDialog } from './edit-release-dialog'
+import { DeleteReleaseDialog } from './delete-release-dialog'
+import { ReleaseArtifactsDialog } from './release-artifacts-dialog'
+
+export function ReleaseManagement() {
+  const [releases, setReleases] = useState<Release[]>([])
+  const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(true)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [productFilter, setProductFilter] = useState<string>('all')
+  const [channelFilter, setChannelFilter] = useState<string>('all')
+  const [editRelease, setEditRelease] = useState<Release | null>(null)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [deleteRelease, setDeleteRelease] = useState<Release | null>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [artifactsRelease, setArtifactsRelease] = useState<Release | null>(null)
+  const [artifactsDialogOpen, setArtifactsDialogOpen] = useState(false)
+  const api = getKeygenApi()
+
+  const loadReleases = useCallback(async () => {
+    try {
+      setLoading(true)
+      const response = await api.releases.list({ limit: 100 })
+      setReleases(response.data || [])
+    } catch (error: unknown) {
+      handleLoadError(error, 'releases')
+    } finally {
+      setLoading(false)
+    }
+  }, [api.releases])
+
+  const loadProducts = useCallback(async () => {
+    try {
+      const response = await api.products.list({ limit: 100 })
+      setProducts(response.data || [])
+    } catch (error: unknown) {
+      handleLoadError(error, 'products')
+    }
+  }, [api.products])
+
+  useEffect(() => {
+    loadReleases()
+    loadProducts()
+  }, [loadReleases, loadProducts])
+
+  const productName = (release: Release): string => {
+    const rel = release.relationships?.product?.data
+    const productId = rel && !Array.isArray(rel) ? rel.id : undefined
+    const product = products.find(p => p.id === productId)
+    return product?.attributes.name || 'Unknown'
+  }
+
+  const filteredReleases = releases.filter(release => {
+    const matchesSearch = !searchTerm ||
+      release.attributes.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      release.attributes.version?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      release.attributes.tag?.toLowerCase().includes(searchTerm.toLowerCase())
+
+    const rel = release.relationships?.product?.data
+    const releaseProductId = rel && !Array.isArray(rel) ? rel.id : undefined
+    const matchesProduct = productFilter === 'all' || releaseProductId === productFilter
+    const matchesChannel = channelFilter === 'all' || release.attributes.channel === channelFilter
+
+    return matchesSearch && matchesProduct && matchesChannel
+  })
+
+  const getStatusColor = (status: ReleaseStatus) => {
+    switch (status) {
+      case 'PUBLISHED': return 'bg-green-100 text-green-800 border-green-200'
+      case 'DRAFT': return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+      case 'YANKED': return 'bg-red-100 text-red-800 border-red-200'
+      default: return 'bg-gray-100 text-gray-800 border-gray-200'
+    }
+  }
+
+  const getChannelColor = (channel: string) => {
+    switch (channel) {
+      case 'stable': return 'bg-blue-100 text-blue-800 border-blue-200'
+      case 'rc': return 'bg-purple-100 text-purple-800 border-purple-200'
+      case 'beta': return 'bg-orange-100 text-orange-800 border-orange-200'
+      default: return 'bg-gray-100 text-gray-800 border-gray-200'
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    })
+  }
+
+  const handlePublish = async (release: Release) => {
+    try {
+      await api.releases.publish(release.id)
+      toast.success(`Release ${release.attributes.version} published`)
+      loadReleases()
+    } catch (error: unknown) {
+      handleCrudError(error, 'update', 'release', { customMessage: 'Failed to publish release' })
+    }
+  }
+
+  const handleYank = async (release: Release) => {
+    try {
+      await api.releases.yank(release.id)
+      toast.success(`Release ${release.attributes.version} yanked`)
+      loadReleases()
+    } catch (error: unknown) {
+      handleCrudError(error, 'update', 'release', { customMessage: 'Failed to yank release' })
+    }
+  }
+
+  const handleArtifacts = (release: Release) => {
+    setArtifactsRelease(release)
+    setArtifactsDialogOpen(true)
+  }
+
+  const handleEdit = (release: Release) => {
+    setEditRelease(release)
+    setEditDialogOpen(true)
+  }
+
+  const handleDelete = (release: Release) => {
+    setDeleteRelease(release)
+    setDeleteDialogOpen(true)
+  }
+
+  return (
+    <div className="space-y-6 px-4 lg:px-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Releases</h1>
+          <p className="text-muted-foreground">
+            Distribute versioned builds and updates of your products
+          </p>
+        </div>
+        <CreateReleaseDialog products={products} onReleaseCreated={loadReleases} />
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Releases</CardTitle>
+            <Rocket className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{releases.length}</div>
+            <p className="text-xs text-muted-foreground">All channels</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Published</CardTitle>
+            <Send className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {releases.filter(r => r.attributes.status === 'PUBLISHED').length}
+            </div>
+            <p className="text-xs text-muted-foreground">Available for download</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Drafts</CardTitle>
+            <Upload className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {releases.filter(r => r.attributes.status === 'DRAFT').length}
+            </div>
+            <p className="text-xs text-muted-foreground">Not yet published</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Yanked</CardTitle>
+            <Ban className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {releases.filter(r => r.attributes.status === 'YANKED').length}
+            </div>
+            <p className="text-xs text-muted-foreground">Access revoked</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters and Search */}
+      <div className="flex items-center space-x-4">
+        <div className="flex-1 max-w-sm">
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search by version, name or tag..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+        </div>
+        <Select value={productFilter} onValueChange={setProductFilter}>
+          <SelectTrigger className="w-[200px]">
+            <Filter className="mr-2 h-4 w-4" />
+            <SelectValue placeholder="Filter by product" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Products</SelectItem>
+            {products.map(product => (
+              <SelectItem key={product.id} value={product.id}>
+                {product.attributes.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={channelFilter} onValueChange={setChannelFilter}>
+          <SelectTrigger className="w-[160px]">
+            <Filter className="mr-2 h-4 w-4" />
+            <SelectValue placeholder="Channel" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Channels</SelectItem>
+            <SelectItem value="stable">Stable</SelectItem>
+            <SelectItem value="rc">RC</SelectItem>
+            <SelectItem value="beta">Beta</SelectItem>
+            <SelectItem value="alpha">Alpha</SelectItem>
+            <SelectItem value="dev">Dev</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Releases Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Release List</CardTitle>
+          <CardDescription>
+            All releases across your products
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center justify-center h-32">
+              <div className="text-sm text-muted-foreground">Loading releases...</div>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Product</TableHead>
+                  <TableHead>Channel</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="w-[70px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredReleases.map((release) => (
+                  <TableRow key={release.id}>
+                    <TableCell>
+                      <code className="px-2 py-1 bg-muted rounded text-xs font-mono">
+                        {release.attributes.version}
+                      </code>
+                    </TableCell>
+                    <TableCell>
+                      <div className="font-medium">
+                        {release.attributes.name || <span className="text-muted-foreground font-normal">Unnamed</span>}
+                      </div>
+                    </TableCell>
+                    <TableCell>{productName(release)}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={`${getChannelColor(release.attributes.channel)} w-fit`}
+                      >
+                        {release.attributes.channel}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={`${getStatusColor(release.attributes.status)} w-fit`}
+                      >
+                        {release.attributes.status.toLowerCase()}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{formatDate(release.attributes.created)}</TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="sm">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => handleArtifacts(release)}>
+                            <FileArchive className="mr-2 h-4 w-4" />
+                            Artifacts
+                          </DropdownMenuItem>
+                          {release.attributes.status === 'DRAFT' && (
+                            <DropdownMenuItem onClick={() => handlePublish(release)}>
+                              <Send className="mr-2 h-4 w-4" />
+                              Publish
+                            </DropdownMenuItem>
+                          )}
+                          {release.attributes.status === 'PUBLISHED' && (
+                            <DropdownMenuItem onClick={() => handleYank(release)}>
+                              <Ban className="mr-2 h-4 w-4" />
+                              Yank
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem onClick={() => handleEdit(release)}>
+                            <Edit className="mr-2 h-4 w-4" />
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-destructive"
+                            onClick={() => handleDelete(release)}
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {!loading && filteredReleases.length === 0 && (
+            <div className="flex items-center justify-center h-32">
+              <div className="text-center">
+                <Rocket className="mx-auto h-8 w-8 text-muted-foreground mb-2" />
+                <div className="text-sm font-medium">No releases found</div>
+                <div className="text-xs text-muted-foreground">
+                  {searchTerm || productFilter !== 'all' || channelFilter !== 'all'
+                    ? 'Try adjusting your search or filters'
+                    : 'Get started by creating your first release'
+                  }
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <EditReleaseDialog
+        release={editRelease}
+        open={editDialogOpen}
+        onOpenChange={setEditDialogOpen}
+        onReleaseUpdated={loadReleases}
+      />
+
+      <DeleteReleaseDialog
+        release={deleteRelease}
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onReleaseDeleted={loadReleases}
+      />
+
+      <ReleaseArtifactsDialog
+        release={artifactsRelease}
+        open={artifactsDialogOpen}
+        onOpenChange={setArtifactsDialogOpen}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Progress as ProgressPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }

--- a/src/components/webhooks/webhook-details-dialog.tsx
+++ b/src/components/webhooks/webhook-details-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { getKeygenApi } from '@/lib/api'
-import { Webhook } from '@/lib/types/keygen'
+import { Webhook, WebhookEventRecord } from '@/lib/types/keygen'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
@@ -23,8 +23,9 @@ export function WebhookDetailsDialog({
   open,
   onOpenChange
 }: WebhookDetailsDialogProps) {
-  const [deliveries, setDeliveries] = useState<Array<{ id: string; attributes?: { event?: string; created?: string; successful?: boolean } }>>([])
+  const [deliveries, setDeliveries] = useState<WebhookEventRecord[]>([])
   const [loadingDeliveries, setLoadingDeliveries] = useState(false)
+  const [retrying, setRetrying] = useState<string | null>(null)
   
   const api = getKeygenApi()
 
@@ -34,7 +35,7 @@ export function WebhookDetailsDialog({
     setLoadingDeliveries(true)
     try {
       const deliveriesResponse = await api.webhooks.getDeliveries(webhook.id, { limit: 10 })
-      setDeliveries((deliveriesResponse.data || []) as Array<{ id: string; attributes?: { event?: string; created?: string; successful?: boolean } }>)
+      setDeliveries((deliveriesResponse.data || []) as WebhookEventRecord[])
     } catch (error: unknown) {
       handleLoadError(error, 'webhook deliveries', { silent: true })
     } finally {
@@ -47,6 +48,21 @@ export function WebhookDetailsDialog({
       loadWebhookDeliveries()
     }
   }, [open, webhook.id, loadWebhookDeliveries])
+
+  const handleRetryDelivery = async (id: string) => {
+    try {
+      setRetrying(id)
+      await api.webhooks.retryEvent(id)
+      toast.success('Delivery re-sent')
+      loadWebhookDeliveries()
+    } catch (error: unknown) {
+      handleCrudError(error, 'update', 'Webhook delivery', {
+        customMessage: 'Failed to retry the delivery',
+      })
+    } finally {
+      setRetrying(null)
+    }
+  }
 
   const handleTestWebhook = async () => {
     try {
@@ -97,7 +113,7 @@ export function WebhookDetailsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <WebhookIcon className="h-5 w-5" />
@@ -251,21 +267,41 @@ export function WebhookDetailsDialog({
                 </div>
               ) : deliveries.length > 0 ? (
                 <div className="space-y-2">
-                  {deliveries.map((delivery, index) => (
-                    <div key={delivery.id || index} className="flex items-center justify-between p-2 border rounded">
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium">
-                          {delivery.attributes?.event || 'Unknown Event'}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {delivery.attributes?.created ? formatDate(delivery.attributes.created) : 'Unknown time'}
-                        </p>
+                  {deliveries.map((delivery, index) => {
+                    const status = delivery.attributes?.status
+                    const failed = status === 'FAILED' || status === 'FAILING'
+                    const code = delivery.attributes?.lastResponseCode
+
+                    return (
+                      <div key={delivery.id || index} className="flex items-center justify-between gap-2 p-2 border rounded">
+                        <div className="min-w-0 space-y-1">
+                          <p className="truncate text-sm font-medium">
+                            {delivery.attributes?.event || 'Unknown Event'}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {delivery.attributes?.created ? formatDate(delivery.attributes.created) : 'Unknown time'}
+                            {code ? ` · HTTP ${code}` : ''}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Badge variant={failed ? 'destructive' : 'default'}>
+                            {status ? status.toLowerCase() : 'unknown'}
+                          </Badge>
+                          {/* Re-send: the usual fix when the endpoint was briefly down. */}
+                          {failed && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={retrying === delivery.id}
+                              onClick={() => handleRetryDelivery(delivery.id)}
+                            >
+                              {retrying === delivery.id ? 'Retrying…' : 'Retry'}
+                            </Button>
+                          )}
+                        </div>
                       </div>
-                      <Badge variant={delivery.attributes?.successful ? 'default' : 'destructive'}>
-                        {delivery.attributes?.successful ? 'Success' : 'Failed'}
-                      </Badge>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               ) : (
                 <div className="text-center py-8">

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -187,6 +187,64 @@ export class KeygenClient {
   }
 
   /**
+   * Like request(), but also returns the response headers. Needed for
+   * endpoints that communicate via the Location header (artifact upload /
+   * download presigned URLs) when called with `Prefer: no-redirect`.
+   */
+  async requestWithHeaders<T = unknown>(
+    endpoint: string,
+    options: ApiRequestOptions = {}
+  ): Promise<{ body: KeygenResponse<T>; headers: Record<string, string>; status: number }> {
+    const url = this.buildUrl(endpoint);
+    const { method = 'GET', headers = {}, body } = options;
+
+    const requestHeaders: Record<string, string> = {
+      'Accept': 'application/vnd.api+json',
+      'Content-Type': 'application/vnd.api+json',
+      ...headers,
+    };
+
+    if (this.config.token) {
+      requestHeaders.Authorization = `Bearer ${this.config.token}`;
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers: requestHeaders,
+      body: body ? JSON.stringify(body) : undefined,
+      redirect: 'manual',
+    });
+
+    let data: KeygenResponse<T> = {};
+    try {
+      data = await response.json();
+    } catch {
+      // Some responses (e.g. redirects) have no JSON body
+    }
+
+    // 3xx responses are not errors here — they carry the Location header
+    if (response.status >= 400) {
+      const apiError: KeygenApiError = {
+        message: data?.errors?.[0]?.detail || data?.errors?.[0]?.title || `HTTP ${response.status} Error`,
+        status: response.status,
+        code: data?.errors?.[0]?.code || `HTTP_${response.status}`,
+        title: data?.errors?.[0]?.title || 'API Error',
+        detail: data?.errors?.[0]?.detail || `Request failed with status ${response.status}`,
+        source: data?.errors?.[0]?.source,
+        errors: data?.errors || [],
+      };
+      throw apiError;
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key.toLowerCase()] = value;
+    });
+
+    return { body: data, headers: responseHeaders, status: response.status };
+  }
+
+  /**
    * Build the full URL for an endpoint
    * In the browser, routes through /api/keygen proxy to avoid CORS issues
    * In singleplayer CE mode, omits the accounts/{accountId} path segment

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -12,6 +12,8 @@ import { EventLogResource } from './resources/event-logs';
 import { PasswordResource } from './resources/passwords';
 import { SearchResource } from './resources/search';
 import { ReleaseResource } from './resources/releases';
+import { TokenResource } from './resources/tokens';
+import { ReleaseMetadataResource } from './resources/release-metadata';
 import { ArtifactResource } from './resources/artifacts';
 
 export class KeygenApi {
@@ -28,6 +30,8 @@ export class KeygenApi {
   public passwords: PasswordResource;
   public search: SearchResource;
   public releases: ReleaseResource;
+  public tokens: TokenResource;
+  public releaseMetadata: ReleaseMetadataResource;
   public artifacts: ArtifactResource;
 
   constructor(private client: KeygenClient) {
@@ -44,6 +48,8 @@ export class KeygenApi {
     this.passwords = new PasswordResource(client);
     this.search = new SearchResource(client);
     this.releases = new ReleaseResource(client);
+    this.tokens = new TokenResource(client);
+    this.releaseMetadata = new ReleaseMetadataResource(client);
     this.artifacts = new ArtifactResource(client);
   }
 
@@ -110,4 +116,6 @@ export { EventLogResource } from './resources/event-logs';
 export { PasswordResource } from './resources/passwords';
 export { SearchResource } from './resources/search';
 export { ReleaseResource } from './resources/releases';
+export { TokenResource } from './resources/tokens';
+export { ReleaseMetadataResource } from './resources/release-metadata';
 export { ArtifactResource } from './resources/artifacts';

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -11,6 +11,8 @@ import { WebhookResource } from './resources/webhooks';
 import { EventLogResource } from './resources/event-logs';
 import { PasswordResource } from './resources/passwords';
 import { SearchResource } from './resources/search';
+import { ReleaseResource } from './resources/releases';
+import { ArtifactResource } from './resources/artifacts';
 
 export class KeygenApi {
   public licenses: LicenseResource;
@@ -25,6 +27,8 @@ export class KeygenApi {
   public eventLogs: EventLogResource;
   public passwords: PasswordResource;
   public search: SearchResource;
+  public releases: ReleaseResource;
+  public artifacts: ArtifactResource;
 
   constructor(private client: KeygenClient) {
     this.licenses = new LicenseResource(client);
@@ -39,6 +43,8 @@ export class KeygenApi {
     this.eventLogs = new EventLogResource(client);
     this.passwords = new PasswordResource(client);
     this.search = new SearchResource(client);
+    this.releases = new ReleaseResource(client);
+    this.artifacts = new ArtifactResource(client);
   }
 
   /**
@@ -103,3 +109,5 @@ export { WebhookResource } from './resources/webhooks';
 export { EventLogResource } from './resources/event-logs';
 export { PasswordResource } from './resources/passwords';
 export { SearchResource } from './resources/search';
+export { ReleaseResource } from './resources/releases';
+export { ArtifactResource } from './resources/artifacts';

--- a/src/lib/api/resources/artifacts.ts
+++ b/src/lib/api/resources/artifacts.ts
@@ -1,0 +1,145 @@
+import { KeygenClient } from '../client';
+import {
+  ReleaseArtifact,
+  ArtifactFilters,
+  KeygenResponse,
+  KeygenListResponse,
+} from '../../types/keygen';
+
+export class ArtifactResource {
+  constructor(private client: KeygenClient) {}
+
+  /**
+   * List artifacts, optionally filtered by release/product/platform/etc.
+   */
+  async list(options?: ArtifactFilters): Promise<KeygenListResponse<ReleaseArtifact>> {
+    const queryParams = new URLSearchParams();
+
+    if (options?.limit) queryParams.set('limit', options.limit.toString());
+    if (options?.release) queryParams.set('release', options.release);
+    if (options?.product) queryParams.set('product', options.product);
+    if (options?.platform) queryParams.set('platform', options.platform);
+    if (options?.arch) queryParams.set('arch', options.arch);
+    if (options?.filetype) queryParams.set('filetype', options.filetype);
+    if (options?.status) queryParams.set('status', options.status);
+
+    const query = queryParams.toString();
+    const endpoint = query ? `/artifacts?${query}` : '/artifacts';
+
+    return this.client.request<ReleaseArtifact[]>(endpoint);
+  }
+
+  /**
+   * Get an artifact without triggering a download redirect
+   * (used for status polling while the upload is being processed)
+   */
+  async get(artifactId: string): Promise<KeygenResponse<ReleaseArtifact>> {
+    const { body } = await this.client.requestWithHeaders<ReleaseArtifact>(
+      `/artifacts/${artifactId}`,
+      { headers: { Prefer: 'no-download' } }
+    );
+    return body;
+  }
+
+  /**
+   * Create an artifact for a release. Returns the artifact plus a presigned
+   * storage URL (from the Location header) that the file must be PUT to.
+   */
+  async create(data: {
+    releaseId: string;
+    filename: string;
+    filesize?: number;
+    filetype?: string;
+    platform?: string;
+    arch?: string;
+    checksum?: string;
+    signature?: string;
+  }): Promise<{ artifact: ReleaseArtifact; uploadUrl: string }> {
+    const { releaseId, ...attributes } = data;
+
+    const { body, headers } = await this.client.requestWithHeaders<ReleaseArtifact>('/artifacts', {
+      method: 'POST',
+      headers: { Prefer: 'no-redirect' },
+      body: {
+        data: {
+          type: 'artifacts',
+          attributes,
+          relationships: {
+            release: {
+              data: { type: 'releases', id: releaseId },
+            },
+          },
+        },
+      },
+    });
+
+    const uploadUrl = headers['location'];
+    if (!body.data || !uploadUrl) {
+      throw new Error('Artifact created but no upload URL was returned');
+    }
+
+    return { artifact: body.data, uploadUrl };
+  }
+
+  /**
+   * Upload the file directly to storage via the presigned URL,
+   * reporting progress. Uses XHR because fetch lacks upload progress.
+   */
+  uploadFile(
+    uploadUrl: string,
+    file: File,
+    onProgress?: (percent: number) => void
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable && onProgress) {
+          onProgress(Math.round((event.loaded / event.total) * 100));
+        }
+      };
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject(new Error(`Upload failed with status ${xhr.status}`));
+        }
+      };
+      xhr.onerror = () => reject(new Error('Upload failed — could not reach storage endpoint'));
+      xhr.onabort = () => reject(new Error('Upload aborted'));
+
+      xhr.send(file);
+    });
+  }
+
+  /**
+   * Get a presigned download URL for an uploaded artifact
+   */
+  async getDownloadUrl(artifactId: string, ttl?: number): Promise<string> {
+    const endpoint = ttl
+      ? `/artifacts/${artifactId}?ttl=${ttl}`
+      : `/artifacts/${artifactId}`;
+
+    const { headers } = await this.client.requestWithHeaders<ReleaseArtifact>(endpoint, {
+      headers: { Prefer: 'no-redirect' },
+    });
+
+    const downloadUrl = headers['location'];
+    if (!downloadUrl) {
+      throw new Error('No download URL available — the artifact may not be uploaded yet');
+    }
+
+    return downloadUrl;
+  }
+
+  /**
+   * Delete (yank) an artifact
+   */
+  async delete(artifactId: string): Promise<void> {
+    await this.client.request<void>(`/artifacts/${artifactId}`, {
+      method: 'DELETE',
+    });
+  }
+}

--- a/src/lib/api/resources/entitlements.ts
+++ b/src/lib/api/resources/entitlements.ts
@@ -90,47 +90,13 @@ export class EntitlementResource {
   }
 
   /**
-   * Get entitlement licenses
+   * NOTE: entitlements are attached from the other side — Keygen mounts
+   * /entitlements as a flat resource with no sub-routes:
+   *
+   *   licenses.attachEntitlements(licenseId, [entitlementId])
+   *   policies.attachEntitlements(policyId, [entitlementId])
+   *
+   * There is likewise no way to list the licences carrying an entitlement:
+   * /licenses has no entitlement filter.
    */
-  async getLicenses(id: string, options: ListOptions = {}): Promise<KeygenResponse<unknown[]>> {
-    const params: Record<string, unknown> = {};
-    if (options.limit) params.limit = options.limit;
-    if (options.page) params.page = options.page;
-
-    return this.client.request(`entitlements/${id}/licenses`, { params });
-  }
-
-  /**
-   * Attach entitlement to licenses
-   */
-  async attachToLicenses(id: string, licenseIds: string[]): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: licenseIds.map(licenseId => ({
-        type: 'licenses',
-        id: licenseId,
-      })),
-    };
-
-    return this.client.request(`entitlements/${id}/relationships/licenses`, {
-      method: 'POST',
-      body,
-    });
-  }
-
-  /**
-   * Detach entitlement from licenses
-   */
-  async detachFromLicenses(id: string, licenseIds: string[]): Promise<void> {
-    const body = {
-      data: licenseIds.map(licenseId => ({
-        type: 'licenses',
-        id: licenseId,
-      })),
-    };
-
-    await this.client.request(`entitlements/${id}/relationships/licenses`, {
-      method: 'DELETE',
-      body,
-    });
-  }
 }

--- a/src/lib/api/resources/groups.ts
+++ b/src/lib/api/resources/groups.ts
@@ -127,27 +127,23 @@ export class GroupResource {
    * Add user to group
    */
   async addUser(id: string, userId: string): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: { type: 'users', id: userId },
-    };
-
-    return this.client.request(`groups/${id}/relationships/users`, {
-      method: 'POST',
-      body,
+    // Group membership is written on the member, not the group: Keygen exposes
+    // no attach endpoint under /groups/:id/users (only index/show).
+    return this.client.request(`users/${userId}/group`, {
+      method: 'PUT',
+      body: { data: { type: 'groups', id } },
     });
   }
 
   /**
    * Remove user from group
    */
-  async removeUser(id: string, userId: string): Promise<void> {
-    const body = {
-      data: { type: 'users', id: userId },
-    };
-
-    await this.client.request(`groups/${id}/relationships/users`, {
-      method: 'DELETE',
-      body,
+  async removeUser(id: string, userId: string): Promise<KeygenResponse<unknown>> {
+    void id;
+    // Clearing the member's group is how it leaves one.
+    return this.client.request(`users/${userId}/group`, {
+      method: 'PUT',
+      body: { data: null },
     });
   }
 
@@ -155,27 +151,20 @@ export class GroupResource {
    * Add license to group
    */
   async addLicense(id: string, licenseId: string): Promise<KeygenResponse<unknown>> {
-    const body = {
-      data: { type: 'licenses', id: licenseId },
-    };
-
-    return this.client.request(`groups/${id}/relationships/licenses`, {
-      method: 'POST',
-      body,
+    return this.client.request(`licenses/${licenseId}/group`, {
+      method: 'PUT',
+      body: { data: { type: 'groups', id } },
     });
   }
 
   /**
    * Remove license from group
    */
-  async removeLicense(id: string, licenseId: string): Promise<void> {
-    const body = {
-      data: { type: 'licenses', id: licenseId },
-    };
-
-    await this.client.request(`groups/${id}/relationships/licenses`, {
-      method: 'DELETE',
-      body,
+  async removeLicense(id: string, licenseId: string): Promise<KeygenResponse<unknown>> {
+    void id;
+    return this.client.request(`licenses/${licenseId}/group`, {
+      method: 'PUT',
+      body: { data: null },
     });
   }
 }

--- a/src/lib/api/resources/groups.ts
+++ b/src/lib/api/resources/groups.ts
@@ -1,5 +1,5 @@
 import { KeygenClient } from '../client';
-import { Group, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
+import { Group, User, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
 
 export interface GroupFilters extends ListOptions {
   name?: string;
@@ -165,6 +165,27 @@ export class GroupResource {
     return this.client.request(`licenses/${licenseId}/group`, {
       method: 'PUT',
       body: { data: null },
+    });
+  }
+
+  /**
+   * Group owners — users who can administer the group.
+   */
+  async listOwners(id: string): Promise<KeygenListResponse<User>> {
+    return this.client.request<User[]>(`groups/${id}/owners`);
+  }
+
+  async attachOwners(id: string, userIds: string[]): Promise<KeygenResponse<unknown>> {
+    return this.client.request(`groups/${id}/owners`, {
+      method: 'POST',
+      body: { data: userIds.map(userId => ({ type: 'users', id: userId })) },
+    });
+  }
+
+  async detachOwners(id: string, userIds: string[]): Promise<void> {
+    await this.client.request(`groups/${id}/owners`, {
+      method: 'DELETE',
+      body: { data: userIds.map(userId => ({ type: 'users', id: userId })) },
     });
   }
 }

--- a/src/lib/api/resources/licenses.ts
+++ b/src/lib/api/resources/licenses.ts
@@ -101,7 +101,7 @@ export class LicenseResource {
       })),
     };
 
-    return this.client.request(`licenses/${id}/relationships/users`, {
+    return this.client.request(`licenses/${id}/users`, {
       method: 'POST',
       body,
     });
@@ -118,7 +118,7 @@ export class LicenseResource {
       })),
     };
 
-    await this.client.request(`licenses/${id}/relationships/users`, {
+    await this.client.request(`licenses/${id}/users`, {
       method: 'DELETE',
       body,
     });
@@ -243,7 +243,7 @@ export class LicenseResource {
       })),
     };
 
-    return this.client.request(`licenses/${id}/relationships/entitlements`, {
+    return this.client.request(`licenses/${id}/entitlements`, {
       method: 'POST',
       body,
     });
@@ -260,7 +260,7 @@ export class LicenseResource {
       })),
     };
 
-    await this.client.request(`licenses/${id}/relationships/entitlements`, {
+    await this.client.request(`licenses/${id}/entitlements`, {
       method: 'DELETE',
       body,
     });
@@ -295,7 +295,7 @@ export class LicenseResource {
       data: { type: 'users', id: userId },
     };
 
-    return this.client.request<License>(`licenses/${id}/user`, {
+    return this.client.request<License>(`licenses/${id}/owner`, {
       method: 'PUT',
       body,
     });

--- a/src/lib/api/resources/licenses.ts
+++ b/src/lib/api/resources/licenses.ts
@@ -1,5 +1,5 @@
 import { KeygenClient } from '../client';
-import { License, LicenseFilters, KeygenResponse, KeygenListResponse } from '@/lib/types/keygen';
+import { License, LicenseFilters, LicenseFile, LicenseValidation, KeygenResponse, KeygenListResponse } from '@/lib/types/keygen';
 
 export class LicenseResource {
   constructor(private client: KeygenClient) {}
@@ -312,6 +312,96 @@ export class LicenseResource {
     return this.client.request<License>(`licenses/${id}/group`, {
       method: 'PUT',
       body,
+    });
+  }
+
+  /**
+   * Validate a licence by ID. Reports whether it is usable and, if not, why
+   * (expired, suspended, no machines, over its machine limit, …) — the first
+   * thing to reach for when a customer says "it stopped working".
+   */
+  async validate(id: string, scope?: {
+    fingerprint?: string;
+    product?: string;
+    policy?: string;
+    machine?: string;
+    version?: string;
+  }): Promise<LicenseValidation> {
+    const body = scope ? { meta: { scope } } : undefined;
+
+    return this.client.request<License>(`licenses/${id}/actions/validate`, {
+      method: 'POST',
+      body,
+    }) as Promise<LicenseValidation>;
+  }
+
+  /**
+   * Validate by licence key, without knowing the licence's ID — this is what a
+   * client app does at activation time.
+   */
+  async validateKey(key: string, scope?: {
+    fingerprint?: string;
+    product?: string;
+  }): Promise<LicenseValidation> {
+    return this.client.request<License>('licenses/actions/validate-key', {
+      method: 'POST',
+      body: {
+        meta: {
+          key,
+          ...(scope ? { scope } : {}),
+        },
+      },
+    }) as Promise<LicenseValidation>;
+  }
+
+  /**
+   * Check out a licence file: a signed snapshot the client verifies offline.
+   * `ttl` (seconds) is how long it stays valid without contacting the server —
+   * i.e. the offline grace window.
+   */
+  async checkOut(id: string, options: {
+    ttl?: number;
+    include?: string[];
+    encrypt?: boolean;
+  } = {}): Promise<KeygenResponse<LicenseFile>> {
+    const params = new URLSearchParams();
+    if (options.ttl) params.set('ttl', options.ttl.toString());
+    if (options.encrypt) params.set('encrypt', '1');
+    if (options.include?.length) params.set('include', options.include.join(','));
+
+    const query = params.toString();
+    const endpoint = `licenses/${id}/actions/check-out${query ? `?${query}` : ''}`;
+
+    return this.client.request<LicenseFile>(endpoint, { method: 'POST' });
+  }
+
+  /**
+   * Check in a licence, resetting its check-in clock (for policies that require
+   * periodic check-ins).
+   */
+  async checkIn(id: string): Promise<KeygenResponse<License>> {
+    return this.client.request<License>(`licenses/${id}/actions/check-in`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Increment usage (for usage-based policies).
+   */
+  async incrementUsage(id: string, increment = 1): Promise<KeygenResponse<License>> {
+    return this.client.request<License>(`licenses/${id}/actions/increment-usage`, {
+      method: 'POST',
+      body: { meta: { increment } },
+    });
+  }
+
+  /**
+   * Revoke a licence permanently. Unlike suspend, this cannot be undone —
+   * suspend is what you want for a customer who has merely stopped paying.
+   */
+  async revoke(id: string): Promise<void> {
+    await this.client.request<void>(`licenses/${id}/actions/revoke`, {
+      method: 'DELETE',
     });
   }
 }

--- a/src/lib/api/resources/policies.ts
+++ b/src/lib/api/resources/policies.ts
@@ -1,5 +1,5 @@
 import { KeygenClient } from '../client';
-import { Policy, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
+import { Policy, PooledKey, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
 
 export class PolicyResource {
   constructor(private client: KeygenClient) {}
@@ -161,6 +161,22 @@ export class PolicyResource {
     await this.client.request(`/policies/${policyId}/entitlements`, {
       method: 'DELETE',
       body,
+    });
+  }
+
+  /**
+   * Pooled keys for this policy (only meaningful when the policy uses a pool).
+   */
+  async listPool(policyId: string): Promise<KeygenListResponse<PooledKey>> {
+    return this.client.request<PooledKey[]>(`policies/${policyId}/pool`);
+  }
+
+  /**
+   * Pop the next key off the pool, removing it.
+   */
+  async popFromPool(policyId: string): Promise<KeygenResponse<PooledKey>> {
+    return this.client.request<PooledKey>(`policies/${policyId}/pool`, {
+      method: 'DELETE',
     });
   }
 }

--- a/src/lib/api/resources/products.ts
+++ b/src/lib/api/resources/products.ts
@@ -1,5 +1,5 @@
 import { KeygenClient } from '../client';
-import { Product, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
+import { Product, Token, KeygenResponse, ListOptions, KeygenListResponse } from '../../types/keygen';
 
 export class ProductResource {
   constructor(private client: KeygenClient) {}
@@ -77,6 +77,44 @@ export class ProductResource {
   async delete(productId: string): Promise<void> {
     await this.client.request<void>(`/products/${productId}`, {
       method: 'DELETE'
+    });
+  }
+
+  /**
+   * List the product's tokens.
+   *
+   * The token secret itself is only ever returned at creation time, so this
+   * shows which tokens exist, not their values.
+   */
+  async listTokens(productId: string): Promise<KeygenListResponse<Token>> {
+    return this.client.request<Token[]>(`/products/${productId}/tokens`);
+  }
+
+  /**
+   * Mint a product-scoped token.
+   *
+   * This is what a build pipeline should use to publish releases — it can only
+   * act on this product, unlike an admin token.
+   *
+   * The secret is returned ONCE, in the response; it cannot be read back later.
+   */
+  async createToken(productId: string, data: {
+    name?: string;
+    expiry?: string | null;
+    permissions?: string[];
+  } = {}): Promise<KeygenResponse<Token>> {
+    return this.client.request<Token>(`/products/${productId}/tokens`, {
+      method: 'POST',
+      body: {
+        data: {
+          type: 'tokens',
+          attributes: {
+            name: data.name,
+            expiry: data.expiry ?? null,
+            ...(data.permissions ? { permissions: data.permissions } : {}),
+          },
+        },
+      },
     });
   }
 }

--- a/src/lib/api/resources/release-metadata.ts
+++ b/src/lib/api/resources/release-metadata.ts
@@ -1,0 +1,45 @@
+import { KeygenClient } from '../client';
+import {
+  ReleasePlatform,
+  ReleaseArch,
+  ReleaseChannelRecord,
+  ReleaseEngine,
+  KeygenListResponse,
+} from '../../types/keygen';
+
+/**
+ * The platforms, architectures, channels and engines the account's releases
+ * actually use.
+ *
+ * Keygen derives these from the artifacts that have been uploaded, so they are
+ * the honest list to filter or populate dropdowns with — better than a
+ * hardcoded guess that drifts from what is really published.
+ */
+export class ReleaseMetadataResource {
+  constructor(private client: KeygenClient) {}
+
+  private listOf<T>(path: string, productId?: string): Promise<KeygenListResponse<T>> {
+    const endpoint = productId ? `products/${productId}/${path}` : path;
+    return this.client.request<T[]>(endpoint);
+  }
+
+  /** e.g. windows, darwin, linux */
+  async platforms(productId?: string): Promise<KeygenListResponse<ReleasePlatform>> {
+    return this.listOf<ReleasePlatform>('platforms', productId);
+  }
+
+  /** e.g. x86_64, arm64 */
+  async arches(productId?: string): Promise<KeygenListResponse<ReleaseArch>> {
+    return this.listOf<ReleaseArch>('arches', productId);
+  }
+
+  /** e.g. stable, rc, beta */
+  async channels(productId?: string): Promise<KeygenListResponse<ReleaseChannelRecord>> {
+    return this.listOf<ReleaseChannelRecord>('channels', productId);
+  }
+
+  /** package engines, e.g. rubygems, npm, oci */
+  async engines(productId?: string): Promise<KeygenListResponse<ReleaseEngine>> {
+    return this.listOf<ReleaseEngine>('engines', productId);
+  }
+}

--- a/src/lib/api/resources/releases.ts
+++ b/src/lib/api/resources/releases.ts
@@ -1,0 +1,126 @@
+import { KeygenClient } from '../client';
+import {
+  Release,
+  ReleaseArtifact,
+  ReleaseChannel,
+  ReleaseStatus,
+  ReleaseFilters,
+  KeygenResponse,
+  KeygenListResponse,
+} from '../../types/keygen';
+
+export class ReleaseResource {
+  constructor(private client: KeygenClient) {}
+
+  /**
+   * List releases, optionally filtered by product, channel or status
+   */
+  async list(options?: ReleaseFilters): Promise<KeygenListResponse<Release>> {
+    const queryParams = new URLSearchParams();
+
+    if (options?.limit) queryParams.set('limit', options.limit.toString());
+    if (options?.product) queryParams.set('product', options.product);
+    if (options?.channel) queryParams.set('channel', options.channel);
+    if (options?.status) queryParams.set('status', options.status);
+    if (options?.page?.size) queryParams.set('page[size]', options.page.size.toString());
+    if (options?.page?.number) queryParams.set('page[number]', options.page.number.toString());
+
+    const query = queryParams.toString();
+    const endpoint = query ? `/releases?${query}` : '/releases';
+
+    return this.client.request<Release[]>(endpoint);
+  }
+
+  /**
+   * Get a specific release by ID
+   */
+  async get(releaseId: string): Promise<KeygenResponse<Release>> {
+    return this.client.request<Release>(`/releases/${releaseId}`);
+  }
+
+  /**
+   * Create a new release (as DRAFT unless status given)
+   */
+  async create(data: {
+    productId: string;
+    version: string;
+    channel: ReleaseChannel;
+    name?: string;
+    description?: string;
+    tag?: string;
+    status?: Exclude<ReleaseStatus, 'YANKED'>;
+    metadata?: Record<string, unknown>;
+  }): Promise<KeygenResponse<Release>> {
+    const { productId, ...attributes } = data;
+
+    return this.client.request<Release>('/releases', {
+      method: 'POST',
+      body: {
+        data: {
+          type: 'releases',
+          attributes,
+          relationships: {
+            product: {
+              data: { type: 'products', id: productId },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Update a release (name, description, tag, metadata)
+   */
+  async update(releaseId: string, data: {
+    name?: string | null;
+    description?: string | null;
+    tag?: string | null;
+    metadata?: Record<string, unknown>;
+  }): Promise<KeygenResponse<Release>> {
+    return this.client.request<Release>(`/releases/${releaseId}`, {
+      method: 'PATCH',
+      body: {
+        data: {
+          type: 'releases',
+          id: releaseId,
+          attributes: data,
+        },
+      },
+    });
+  }
+
+  /**
+   * Publish a draft release, making it available for download
+   */
+  async publish(releaseId: string): Promise<KeygenResponse<Release>> {
+    return this.client.request<Release>(`/releases/${releaseId}/actions/publish`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Yank a published release, revoking download access
+   */
+  async yank(releaseId: string): Promise<KeygenResponse<Release>> {
+    return this.client.request<Release>(`/releases/${releaseId}/actions/yank`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Delete a release permanently (artifacts included)
+   */
+  async delete(releaseId: string): Promise<void> {
+    await this.client.request<void>(`/releases/${releaseId}`, {
+      method: 'DELETE',
+    });
+  }
+
+  /**
+   * List artifacts belonging to a release
+   */
+  async listArtifacts(releaseId: string): Promise<KeygenListResponse<ReleaseArtifact>> {
+    return this.client.request<ReleaseArtifact[]>(`/releases/${releaseId}/artifacts`);
+  }
+}

--- a/src/lib/api/resources/tokens.ts
+++ b/src/lib/api/resources/tokens.ts
@@ -1,0 +1,38 @@
+import { KeygenClient } from '../client';
+import { Token, KeygenResponse, KeygenListResponse, ListOptions } from '../../types/keygen';
+
+/**
+ * Account-wide API tokens.
+ *
+ * The secret is only returned when a token is generated or regenerated — it is
+ * never readable afterwards, so a lost token has to be regenerated or replaced.
+ */
+export class TokenResource {
+  constructor(private client: KeygenClient) {}
+
+  async list(options: ListOptions = {}): Promise<KeygenListResponse<Token>> {
+    const params: Record<string, unknown> = {};
+    if (options.limit) params.limit = options.limit;
+    if (options.page) params.page = options.page;
+
+    return this.client.request<Token[]>('tokens', { params });
+  }
+
+  async get(id: string): Promise<KeygenResponse<Token>> {
+    return this.client.request<Token>(`tokens/${id}`);
+  }
+
+  /**
+   * Issue a new secret for an existing token, invalidating the old one.
+   */
+  async regenerate(id: string): Promise<KeygenResponse<Token>> {
+    return this.client.request<Token>(`tokens/${id}`, { method: 'PUT' });
+  }
+
+  /**
+   * Revoke a token. Anything still using it stops working immediately.
+   */
+  async revoke(id: string): Promise<void> {
+    await this.client.request<void>(`tokens/${id}`, { method: 'DELETE' });
+  }
+}

--- a/src/lib/api/resources/users.ts
+++ b/src/lib/api/resources/users.ts
@@ -189,7 +189,7 @@ export class UserResource {
       data: { type: 'groups', id: groupId },
     };
 
-    return this.client.request<User>(`users/${id}/relationships/group`, {
+    return this.client.request<User>(`users/${id}/group`, {
       method: 'PATCH',
       body,
     });

--- a/src/lib/api/resources/webhooks.ts
+++ b/src/lib/api/resources/webhooks.ts
@@ -1,5 +1,5 @@
 import { KeygenClient } from '../client';
-import { Webhook, WebhookFilters, KeygenResponse, KeygenListResponse } from '../../types/keygen';
+import { Webhook, WebhookFilters, WebhookEventRecord, KeygenResponse, KeygenListResponse } from '../../types/keygen';
 
 // Common webhook events in Keygen
 export const WEBHOOK_EVENTS = [
@@ -200,5 +200,37 @@ export class WebhookResource {
     });
 
     return categories;
+  }
+
+  /**
+   * List delivery attempts across all endpoints.
+   */
+  async listEvents(options: {
+    limit?: number;
+    page?: number;
+  } = {}): Promise<KeygenListResponse<WebhookEventRecord>> {
+    const params: Record<string, unknown> = {};
+    if (options.limit) params.limit = options.limit;
+    if (options.page) params.page = options.page;
+
+    return this.client.request<WebhookEventRecord[]>('webhook-events', { params });
+  }
+
+  async getEvent(id: string): Promise<KeygenResponse<WebhookEventRecord>> {
+    return this.client.request<WebhookEventRecord>(`webhook-events/${id}`);
+  }
+
+  /**
+   * Re-send a delivery that failed — the usual fix when a customer's endpoint
+   * was briefly down.
+   */
+  async retryEvent(id: string): Promise<KeygenResponse<WebhookEventRecord>> {
+    return this.client.request<WebhookEventRecord>(`webhook-events/${id}/actions/retry`, {
+      method: 'POST',
+    });
+  }
+
+  async deleteEvent(id: string): Promise<void> {
+    await this.client.request<void>(`webhook-events/${id}`, { method: 'DELETE' });
   }
 }

--- a/src/lib/types/keygen.ts
+++ b/src/lib/types/keygen.ts
@@ -209,6 +209,88 @@ export interface Entitlement extends KeygenResource {
   };
 }
 
+// Result of validating a licence: `valid` plus a machine-readable code
+// (EXPIRED, SUSPENDED, NO_MACHINE, TOO_MANY_MACHINES, …) and a readable detail.
+export interface LicenseValidation extends KeygenResponse<License> {
+  meta?: {
+    ts?: string;
+    valid: boolean;
+    detail: string;
+    code: string;
+    scope?: Record<string, unknown>;
+  };
+}
+
+// A signed licence file: the client verifies `certificate` offline.
+export interface LicenseFile extends KeygenResource {
+  type: 'license-files';
+  attributes: {
+    certificate: string;
+    algorithm: string;
+    /** Seconds the file stays valid without contacting the server. */
+    ttl: number | null;
+    issued: string;
+    expiry: string | null;
+  };
+}
+
+// A single webhook delivery attempt.
+export interface WebhookEventRecord extends KeygenResource {
+  type: 'webhook-events';
+  attributes: {
+    endpoint: string;
+    event: string;
+    payload?: string;
+    status: 'DELIVERING' | 'DELIVERED' | 'FAILING' | 'FAILED';
+    lastResponseCode?: number | null;
+    lastResponseBody?: string | null;
+    created: string;
+    updated: string;
+  };
+}
+
+// Release metadata — Keygen derives these from uploaded artifacts.
+export interface ReleasePlatform extends KeygenResource {
+  type: 'platforms';
+  attributes: { key: string; created: string; updated: string };
+}
+
+export interface ReleaseArch extends KeygenResource {
+  type: 'arches';
+  attributes: { key: string; created: string; updated: string };
+}
+
+export interface ReleaseChannelRecord extends KeygenResource {
+  type: 'channels';
+  attributes: { key: string; name?: string; created: string; updated: string };
+}
+
+export interface ReleaseEngine extends KeygenResource {
+  type: 'engines';
+  attributes: { key: string; name?: string; created: string; updated: string };
+}
+
+// A pooled licence key (policies with usePool draw from these).
+export interface PooledKey extends KeygenResource {
+  type: 'keys';
+  attributes: { key: string; created: string; updated: string };
+}
+
+// Token
+export interface Token extends KeygenResource {
+  type: 'tokens';
+  attributes: {
+    kind: string;
+    /** Only returned when the token is first created — it cannot be read back. */
+    token?: string;
+    name?: string;
+    expiry?: string | null;
+    permissions?: string[];
+    created: string;
+    updated: string;
+  };
+}
+
 // Release
 export type ReleaseChannel = 'stable' | 'rc' | 'beta' | 'alpha' | 'dev';
 export type ReleaseStatus = 'DRAFT' | 'PUBLISHED' | 'YANKED';

--- a/src/lib/types/keygen.ts
+++ b/src/lib/types/keygen.ts
@@ -209,6 +209,46 @@ export interface Entitlement extends KeygenResource {
   };
 }
 
+// Release
+export type ReleaseChannel = 'stable' | 'rc' | 'beta' | 'alpha' | 'dev';
+export type ReleaseStatus = 'DRAFT' | 'PUBLISHED' | 'YANKED';
+
+export interface Release extends KeygenResource {
+  type: 'releases';
+  attributes: {
+    name?: string;
+    description?: string;
+    version: string;
+    channel: ReleaseChannel;
+    status: ReleaseStatus;
+    tag?: string;
+    metadata?: Record<string, unknown>;
+    created: string;
+    updated: string;
+    yanked?: string;
+  };
+}
+
+// Release Artifact
+export type ArtifactStatus = 'WAITING' | 'PROCESSING' | 'UPLOADED' | 'FAILED' | 'YANKED';
+
+export interface ReleaseArtifact extends KeygenResource {
+  type: 'artifacts';
+  attributes: {
+    filename: string;
+    filetype?: string | null;
+    filesize?: number | null;
+    platform?: string | null;
+    arch?: string | null;
+    signature?: string | null;
+    checksum?: string | null;
+    status: ArtifactStatus;
+    metadata?: Record<string, unknown>;
+    created: string;
+    updated: string;
+  };
+}
+
 // Process
 export interface Process extends KeygenResource {
   type: 'processes';
@@ -364,4 +404,19 @@ export interface WebhookFilters extends PaginationOptions {
   enabled?: boolean;
   url?: string;
   subscriptions?: string[];
+}
+
+export interface ReleaseFilters extends PaginationOptions {
+  product?: string;
+  channel?: ReleaseChannel;
+  status?: ReleaseStatus;
+}
+
+export interface ArtifactFilters extends PaginationOptions {
+  release?: string;
+  product?: string;
+  platform?: string;
+  arch?: string;
+  filetype?: string;
+  status?: ArtifactStatus;
 }


### PR DESCRIPTION
> **Stacked PR.** This branch builds on #25 (releases) and #24 (endpoint fixes) because it touches the same files. **Review the last commit only** — the rest is those PRs. It rebases cleanly once they land.

Fills in the parts of the Keygen API the dashboard did not reach. Endpoints cited against [`config/routes.rb`](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb).

---

## Product tokens ([routes.rb#L301](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L301))

`POST /products/:id/tokens` — a **product-scoped** token.

This matters for security, not convenience: publishing a release from CI currently means putting an **admin token** in the pipeline, and a leaked CI secret then owns every license and product in the account. A product token can only act on its own product.

The dialog surfaces the secret **once**, with a copy button and an explicit warning, because Keygen never returns it again.

## License actions ([routes.rb#L253-L266](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L253-L266))

`validate`, `validate-key`, `check-out`, `check-in`, `increment-usage`, `revoke`.

**Validate** is surfaced in the license row menu, and it answers a question the UI could not: *why* is this license not working? It returns a code — `EXPIRED`, `SUSPENDED`, `NO_MACHINE`, `TOO_MANY_MACHINES`, … — with a human-readable detail.

The status column cannot tell you this. An `active` license that has consumed every seat still shows as "active", and the customer still cannot activate their next machine. This is the first thing support reaches for.

`check-out` returns the signed license file used for offline verification; `revoke` is distinguished from suspend (irreversible vs. reversible) in the doc comment, since confusing them is expensive.

## Webhook events ([routes.rb#L394-L400](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L394-L400))

`list`, `retry`, `delete`, plus a **Retry** button on failed deliveries — the usual fix when a customer's endpoint was briefly down.

While wiring this up I found the existing delivery list reads `attributes.successful`, **which the API does not return**. Real events carry `status` (`DELIVERING`/`DELIVERED`/`FAILING`/`FAILED`) and `lastResponseCode`, so **every delivery rendered as "Failed"** regardless of outcome. Now typed and rendered correctly, with the HTTP response code shown.

## Also added

- **Account tokens** (`/tokens`, [L122](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L122)) — list, regenerate, revoke.
- **Release metadata** (`/platforms`, `/arches`, `/channels`, `/engines`) — Keygen derives these from artifacts already uploaded, so the artifact dialog's platform/arch dropdowns now reflect **what you have actually published** instead of a hardcoded array (kept as a fallback).
- **Pooled keys** (`/policies/:id/pool`, [L281](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L281)).
- **Group owners** (`/groups/:id/owners`, [L383](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L383)).

## Deliberately NOT added

The release **upgrade** endpoint. It looks like the obvious thing for an auto-updater, but it is wrapped in `version_constraint '<=1.0'` ([routes.rb#L318-L332](https://github.com/keygen-sh/keygen-api/blob/master/config/routes.rb#L318-L332)) — it is a deprecated v1.0 route. Modern clients list releases and compare versions themselves. Adding it would have baked a dead endpoint into the client.

---

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm build` pass. Exercised against a self-hosted **Keygen CE 1.8** instance.